### PR TITLE
feat(dismiss-prospect): add sns subscription for dismiss-prospect event

### DIFF
--- a/.aws/src/config/index.ts
+++ b/.aws/src/config/index.ts
@@ -55,6 +55,7 @@ export const config = {
   eventBridge: {
     prefix: 'PocketEventBridge',
     userTopic: 'UserEventTopic',
+    prospectEventTopic: 'ProspectEventTopic'
   },
   envVars: {
     snowplowEndpoint: snowplowEndpoint,

--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -60,7 +60,7 @@ class SnowplowSharedConsumerStack extends TerraformStack {
     });
 
     //dlq for sqs-sns subscription
-    const snsTopicDlq = new sqs.SqsQueue(this, 'sns-topic-dql', {
+    const snsTopicDlq = new sqs.SqsQueue(this, 'sns-topic-dlq', {
       name: `${config.prefix}-SNS-Topics-DLQ`,
       tags: config.tags,
     });

--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -206,7 +206,6 @@ class SnowplowSharedConsumerStack extends TerraformStack {
       { name: 'shared-snowplow-consumer-sns-sqs', resource: snsTopicQueue },
       { name: 'shared-snowplow-consumer-sns-dlq', resource: snsTopicDlq },
     ].forEach((queue) => {
-      console.log(queue.resource.policy);
       const policy = new iam.DataAwsIamPolicyDocument(
         this,
         `${queue.name}-policy-document`,

--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -51,15 +51,48 @@ class SnowplowSharedConsumerStack extends TerraformStack {
 
     const pagerDuty = this.createPagerDuty();
 
-    // Create Lambda to consume from pocket-shared-event-bus and send it to snowplow
+    // Create Lambda to consume from pocket-shared-event-bus.
+    //this will forward the event-bridge content to ECS.
+    //if we are not successfully sending to ECS, the messages will be stored in DLQ.
     const sqsEventLambda = new SQSConsumerLambda(this, 'SharedEventConsumer', {
       vpc: pocketVPC,
       pagerDuty,
     });
 
-    const userEventTopicArn = `arn:aws:sns:${region.name}:${caller.accountId}:${config.eventBridge.prefix}-${config.environment}-${config.eventBridge.userTopic}`;
-    this.subscribeSqsToSnsTopic(sqsEventLambda, userEventTopicArn);
+    //dlq for sqs-sns subscription
+    const snsTopicDlq = new sqs.SqsQueue(this, 'sns-topic-dql', {
+      name: `${config.prefix}-SNS-Topics-DLQ`,
+      tags: config.tags,
+    });
 
+    const userEventTopicArn = `arn:aws:sns:${region.name}:${caller.accountId}:${config.eventBridge.prefix}-${config.environment}-${config.eventBridge.userTopic}`;
+    this.subscribeSqsToSnsTopic(
+      sqsEventLambda,
+      snsTopicDlq,
+      userEventTopicArn,
+      config.eventBridge.userTopic
+    );
+
+    //as of now, listens to dismiss-prospect events from prospect-api
+    const prospectEventTopicArn = `arn:aws:sns:${region.name}:${caller.accountId}:${config.eventBridge.prefix}-${config.environment}-${config.eventBridge.prospectEventTopic}`;
+    this.subscribeSqsToSnsTopic(
+      sqsEventLambda,
+      snsTopicDlq,
+      prospectEventTopicArn,
+      config.eventBridge.prospectEventTopic
+    );
+
+    const SNSTopicsSubscriptionList = [userEventTopicArn, prospectEventTopicArn]
+    //assigns inline access policy for SQS and DLQ.
+    //include sns topic that we want the queue to subscribe to within this policy.
+    this.createPoliciesForAccountDeletionMonitoringSqs(
+      sqsEventLambda.construct.applicationSqsQueue.sqsQueue,
+      snsTopicDlq,
+      SNSTopicsSubscriptionList
+    );
+
+
+    //ecs app creation.
     const appProps: SharedSnowplowConsumerProps = {
       pagerDuty: pagerDuty,
       region: region,
@@ -95,21 +128,28 @@ class SnowplowSharedConsumerStack extends TerraformStack {
     });
   }
 
+  /**
+   * Create SQS subscription for the SNS.
+   * @param sqsLambda SQS integrated with the snowplow-consumer-lambda
+   * @param snsTopicArn topic the SQS wants to subscribe to.
+   * @param snsTopicDlq the DLQ to which the messages will be forwarded if SQS is down
+   * @param topicName topic we want to subscribe to.
+   * @private
+   */
   private subscribeSqsToSnsTopic(
     sqsLambda: SQSConsumerLambda,
-    snsTopicArn: string
+    snsTopicDlq: sqs.SqsQueue,
+    snsTopicArn: string,
+    topicName: string
   ) {
-    // Subscribe to SNS topic with user-related events
     // This Topic already exists and is managed elsewhere
-    new ApplicationSqsSnsTopicSubscription(this, 'user-event-subscription', {
-      name: 'Shared-Snowplow-Consumer-Events',
-      snsTopicArn,
-      sqsQueue: sqsLambda.construct.sqsQueueResource,
-      tags: { environment: config.environment, service: config.name },
-      dependsOn: [
-        sqsLambda.construct.lambda.versionedLambda,
-        sqsLambda.construct.sqsQueueResource as sqs.SqsQueue,
-      ],
+    return new sns.SnsTopicSubscription(this, `${topicName}-sns-subscription`, {
+      topicArn: snsTopicArn,
+      protocol: 'sqs',
+      endpoint: sqsLambda.construct.applicationSqsQueue.sqsQueue.arn,
+      redrivePolicy: JSON.stringify({
+        deadLetterTargetArn: snsTopicDlq.arn,
+      }),
     });
   }
 
@@ -139,6 +179,67 @@ class SnowplowSharedConsumerStack extends TerraformStack {
           .get('policy_backend_non_critical_id')
           .toString(),
       },
+    });
+  }
+
+  /**
+   * Create inline IAM policy for the SQS and DLQ tied to the lambda
+   * Note: we need to append any additional IAM policy to this.
+   * Re-running this with a different iam would replace the inline access policy.
+   * @param
+   * @private
+   */
+
+  /**
+   *
+   * @param snsTopicQueue SQS that triggers the lambda
+   * @param snsTopicDlq DLQ to which the messages will be forwarded if SQS is down
+   * @param snsTopicArns list of SNS topic to which we want to subscribe to
+   * @private
+   */
+  private createPoliciesForAccountDeletionMonitoringSqs(
+    snsTopicQueue: sqs.SqsQueue,
+    snsTopicDlq: sqs.SqsQueue,
+    snsTopicArns: string[]
+  ): void {
+    [
+      { name: 'shared-snowplow-consumer-sns-sqs', resource: snsTopicQueue },
+      { name: 'shared-snowplow-consumer-sns-dlq', resource: snsTopicDlq },
+    ].forEach((queue) => {
+      console.log(queue.resource.policy);
+      const policy = new iam.DataAwsIamPolicyDocument(
+        this,
+        `${queue.name}-policy-document`,
+        {
+          statement: [
+            {
+              effect: 'Allow',
+              actions: ['sqs:SendMessage'],
+              resources: [queue.resource.arn],
+              principals: [
+                {
+                  identifiers: ['sns.amazonaws.com'],
+                  type: 'Service',
+                },
+              ],
+              condition: [
+                {
+                  test: 'ArnLike',
+                  variable: 'aws:SourceArn',
+                  //add any sns topic to this list that we want this SQS to listen to
+                  values: snsTopicArns,
+                },
+              ],
+            },
+            //add any other subscription policy for this SQS
+          ],
+        }
+      ).json;
+
+      new sqs.SqsQueuePolicy(this, `${queue.name}-policy`, {
+        queueUrl: queue.resource.url,
+        policy: policy,
+      });
     });
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,11 +1,21 @@
 # SharedSnowplowConsumer
 
-shared consumer for consuming from event-bridge and emitting to snowplow 
+shared consumer for consuming from event-bridge and emitting to snowplow.
+Architecutre diagram: https://miro.com/app/board/uXjVO5oHq_U=/
 
 ## Folder structure
 - the infrastructure code is present in `.aws`
   - to add a new event, add the sns subscription of the event to the `sqsConsumerLambda`
-- the application code is in `src/lambda`
+  - and append the SNS permissions with the existing inline access policy
+  
+
+- the `lambda` folder contains the SQSLambda code. This listens to the SNS and forward 
+  the event and its payload to the ecs application to the `sendEvents` POST endpoints
+  - if the ECS is down or any error thrown by sendEvents endpoint , it will forward 
+    the messages to its DLQ.
+
+
+- the ECS application code is in `src`. This sends the event to snowplow.
   - the `eventConsumer` contains logic to consume from event-bridge and transform them to snowplow
   - the `snowplow` folder contains handlers to send events to snowplow
 - `.docker` contains local setup
@@ -15,6 +25,21 @@ shared consumer for consuming from event-bridge and emitting to snowplow
 ```bash
 npm install
 npm start:dev
+```
+
+## To run test for ecs
+```bash
+npm ci
+npm run test
+npm run test-integrations
+```
+
+## To run test for lambda
+```bash
+cd lambda
+npm ci
+npm run test
+npm run test-integrations
 ```
 
 ## Start docker


### PR DESCRIPTION
## Goal
add sns subscription for dismiss-prospect event to the SQS lambda.

## Implementation Decisions
- sns subscription for SQS and its DLQ
- extracted inline policy attachment from terraform-modules to here
so we can attach multiple SNS subscription permission to this sqs. 

pocket event-bridge rules to tie the event->sns is created in this PR: https://github.com/Pocket/pocket-event-bridge/pull/75

- [Deployed to dev](https://us-east-1.console.aws.amazon.com/sqs/v2/home?region=us-east-1#/queues/https%3A%2F%2Fsqs.us-east-1.amazonaws.com%2F410318598490%2FSharedSnowplowConsumer-Dev-SharedEventConsumer-Queue)
- [ecs logs for dismiss-prospect test event](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Fecs$252FSharedSnowplowConsumer-Dev$252Fapp20221011002022854900000002/log-events/ecs$252Fapp$252Fe934ff03f676440faa4918bd71eff92c)

Ticket: https://getpocket.atlassian.net/browse/BACK-1623