### PR TITLE
refactor(tracking): remove async/await where not needed

### DIFF
--- a/src/eventConsumer/index.ts
+++ b/src/eventConsumer/index.ts
@@ -9,7 +9,7 @@ export enum EventType {
 // Mapping of detail-type (via event bridge message)
 // to function that should be invoked to process the message
 export const eventConsumer: {
-  [key: string]: (message: any) => Promise<void>;
+  [key: string]: (message: any) => void;
 } = {
   [EventType.ACCOUNT_DELETION]: userEventConsumer,
   [EventType.ACCOUNT_EMAIL_UPDATED]: userEventConsumer,

--- a/src/eventConsumer/userEvents/userEventConsumer.ts
+++ b/src/eventConsumer/userEvents/userEventConsumer.ts
@@ -30,9 +30,9 @@ export const DetailTypeToSnowplowMap: Record<string, EventTypeString> = {
   'account-email-updated': 'ACCOUNT_EMAIL_UPDATED',
 };
 
-export async function userEventConsumer(requestBody: any) {
+export function userEventConsumer(requestBody: any) {
   console.log(`requestBody -> ${JSON.stringify(requestBody)}`);
-  await new UserEventHandler().process(getUserEventPayload(requestBody));
+  new UserEventHandler().process(getUserEventPayload(requestBody));
 }
 
 /**

--- a/src/snowplow/userEventHandler.integration.ts
+++ b/src/snowplow/userEventHandler.integration.ts
@@ -105,7 +105,7 @@ describe('SnowplowHandler', () => {
   });
 
   it('should send account delete event to snowplow', async () => {
-    await new UserEventHandler().process({
+    new UserEventHandler().process({
       ...testEventData,
       eventType: EventType.ACCOUNT_DELETE,
     });
@@ -132,7 +132,7 @@ describe('SnowplowHandler', () => {
   });
 
   it('should send update email event to snowplow', async () => {
-    await new UserEventHandler().process({
+    new UserEventHandler().process({
       ...testEventData,
       eventType: EventType.ACCOUNT_EMAIL_UPDATED,
     });

--- a/src/snowplow/userEventHandler.ts
+++ b/src/snowplow/userEventHandler.ts
@@ -35,13 +35,13 @@ export class UserEventHandler extends EventHandler {
    * method to create and process event data
    * @param data
    */
-  async process(data: UserEventPayloadSnowplow): Promise<void> {
+  process(data: UserEventPayloadSnowplow): void {
     this.addRequestInfoToTracker(data);
     const event = buildSelfDescribingEvent({
       event: UserEventHandler.generateAccountUpdateEvent(data),
     });
     const context = UserEventHandler.generateEventContext(data);
-    await super.track(event, context);
+    super.addToTrackerQueue(event, context);
   }
 
   /**


### PR DESCRIPTION
## Goal

slight changes to make the code here better reflect the reality of the @snowplow/node-tracker package. removes async/await calls where not applicable.

- rename `track` method to reflect actual code effect

## I'd love feedback/perspectives on:
- renaming `track` to `addToTrackerQueue`. the new method name is verbose, but i think captures the effect of the code accurately. open to other options though.

## Implementation Decisions
- removed `async`/`await` so nobody gets the wrong idea about the @snowplow/node-tracker package.