### PR TITLE
fix(sns-subscriptions): remove user-events subscription for now

### DIFF
--- a/.aws/package.json
+++ b/.aws/package.json
@@ -13,7 +13,7 @@
     "test": "echo ok"
   },
   "engines": {
-    "node": "=12"
+    "node": ">=12"
   },
   "dependencies": {
     "@pocket-tools/terraform-modules": "4.4.0"

--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -65,13 +65,13 @@ class SnowplowSharedConsumerStack extends TerraformStack {
       tags: config.tags,
     });
 
-    const userEventTopicArn = `arn:aws:sns:${region.name}:${caller.accountId}:${config.eventBridge.prefix}-${config.environment}-${config.eventBridge.userTopic}`;
-    this.subscribeSqsToSnsTopic(
-      sqsEventLambda,
-      snsTopicDlq,
-      userEventTopicArn,
-      config.eventBridge.userTopic
-    );
+    // const userEventTopicArn = `arn:aws:sns:${region.name}:${caller.accountId}:${config.eventBridge.prefix}-${config.environment}-${config.eventBridge.userTopic}`;
+    // this.subscribeSqsToSnsTopic(
+    //   sqsEventLambda,
+    //   snsTopicDlq,
+    //   userEventTopicArn,
+    //   config.eventBridge.userTopic
+    // );
 
     //as of now, listens to dismiss-prospect events from prospect-api
     const prospectEventTopicArn = `arn:aws:sns:${region.name}:${caller.accountId}:${config.eventBridge.prefix}-${config.environment}-${config.eventBridge.prospectEventTopic}`;
@@ -82,7 +82,10 @@ class SnowplowSharedConsumerStack extends TerraformStack {
       config.eventBridge.prospectEventTopic
     );
 
-    const SNSTopicsSubscriptionList = [userEventTopicArn, prospectEventTopicArn]
+    const SNSTopicsSubscriptionList = [
+      //userEventTopicArn,
+      prospectEventTopicArn,
+    ];
     //assigns inline access policy for SQS and DLQ.
     //include sns topic that we want the queue to subscribe to within this policy.
     this.createPoliciesForAccountDeletionMonitoringSqs(
@@ -90,7 +93,6 @@ class SnowplowSharedConsumerStack extends TerraformStack {
       snsTopicDlq,
       SNSTopicsSubscriptionList
     );
-
 
     //ecs app creation.
     const appProps: SharedSnowplowConsumerProps = {

--- a/lambda/index.ts
+++ b/lambda/index.ts
@@ -7,7 +7,7 @@ export async function processor(event: any): Promise<any> {
   for await (const record of event.Records) {
     try {
       const requestBody = JSON.parse(JSON.parse(record.body).Message);
-      console.log(`message received -> ${JSON.stringify(requestBody)}`);
+      console.log(`message received-> ${JSON.stringify(requestBody)}`);
       await callSendEventEndpoint(requestBody);
     } catch (error) {
       console.log(

--- a/src/eventConsumer/prospectEvents/prospectEventConsumer.spec.ts
+++ b/src/eventConsumer/prospectEvents/prospectEventConsumer.spec.ts
@@ -1,19 +1,22 @@
 import { getProspectEventPayload } from './prospectEventConsumer';
 import { ProspectEventPayloadSnowplow } from '../../snowplow/prospect/types';
-import { testProspectData } from '../../snowplow/prospect/testData';
+import {
+  eventBridgeTestPayload,
+  testProspectData,
+} from '../../snowplow/prospect/testData';
 
 describe('getProspectEventPayload', () => {
   it('should convert request body to Prospect', () => {
     const expected: ProspectEventPayloadSnowplow = {
       object_version: 'new',
-      prospect: testProspectData,
+      prospect: eventBridgeTestPayload['prospect'],
       eventType: 'PROSPECT_REVIEWED',
     };
 
     const requestBody = {
       'detail-type': 'prospect-dismiss',
       source: 'prospect-events',
-      detail: testProspectData,
+      detail: eventBridgeTestPayload,
     };
 
     const payload = getProspectEventPayload(requestBody);

--- a/src/eventConsumer/prospectEvents/prospectEventConsumer.spec.ts
+++ b/src/eventConsumer/prospectEvents/prospectEventConsumer.spec.ts
@@ -1,9 +1,6 @@
 import { getProspectEventPayload } from './prospectEventConsumer';
 import { ProspectEventPayloadSnowplow } from '../../snowplow/prospect/types';
-import {
-  eventBridgeTestPayload,
-  testProspectData,
-} from '../../snowplow/prospect/testData';
+import { eventBridgeTestPayload } from '../../snowplow/prospect/testData';
 
 describe('getProspectEventPayload', () => {
   it('should convert request body to Prospect', () => {

--- a/src/eventConsumer/prospectEvents/prospectEventConsumer.ts
+++ b/src/eventConsumer/prospectEvents/prospectEventConsumer.ts
@@ -30,7 +30,7 @@ export function getProspectEventPayload(
   const eventPayload: ProspectEventBusPayload = eventObj['detail'];
   const detailType = eventObj['detail-type'];
   return {
-    prospect: eventPayload,
+    prospect: eventPayload['prospect'],
     object_version: 'new',
     eventType: DetailTypeToSnowplowMap[detailType],
   };

--- a/src/routes/sendEvent.ts
+++ b/src/routes/sendEvent.ts
@@ -16,7 +16,7 @@ router.post('/', async (req, res) => {
     );
   }
 
-  await eventConsumer[detailType](req.body);
+  eventConsumer[detailType](req.body);
 
   return res.send({
     status: 'OK',

--- a/src/snowplow/prospect/prospectEventHandler.ts
+++ b/src/snowplow/prospect/prospectEventHandler.ts
@@ -3,7 +3,6 @@ import { SelfDescribingJson } from '@snowplow/tracker-core';
 import {
   ObjectUpdate,
   ProspectEventPayloadSnowplow,
-  ProspectReviewStatus,
   SnowplowEventMap,
 } from './types';
 import { config } from '../../config';
@@ -34,7 +33,7 @@ type ProspectContext = Omit<SelfDescribingJson, 'data'> & {
     created_at: number; // A Unix timestamp
     reviewed_by?: string;
     reviewed_at?: number; // A Unix timestamp
-    prospect_review_status: ProspectReviewStatus;
+    prospect_review_status: string;
   };
 };
 

--- a/src/snowplow/prospect/prospectEventHandler.ts
+++ b/src/snowplow/prospect/prospectEventHandler.ts
@@ -81,6 +81,7 @@ export class ProspectEventHandler extends EventHandler {
   private static generateReviewedEventAccountContext(
     data: ProspectEventPayloadSnowplow
   ): ProspectContext {
+    const authorArray: string[] = data.prospect.authors.split(',');
     return {
       schema: config.snowplow.schemas.prospect,
       data: {
@@ -94,7 +95,7 @@ export class ProspectEventHandler extends EventHandler {
         topic: data.prospect.topic,
         is_collection: data.prospect.isCollection,
         is_syndicated: data.prospect.isSyndicated,
-        authors: data.prospect.authors.split(','),
+        authors: authorArray,
         publisher: data.prospect.publisher,
         domain: data.prospect.domain,
         prospect_source: data.prospect.prospectType,

--- a/src/snowplow/prospect/prospectEventHandler.ts
+++ b/src/snowplow/prospect/prospectEventHandler.ts
@@ -81,6 +81,9 @@ export class ProspectEventHandler extends EventHandler {
   private static generateReviewedEventAccountContext(
     data: ProspectEventPayloadSnowplow
   ): ProspectContext {
+    console.log(
+      `generateReviewedEventAccountContext(): data -> ${JSON.stringify(data)}`
+    );
     const authorArray: string[] = data.prospect.authors.split(',');
     return {
       schema: config.snowplow.schemas.prospect,

--- a/src/snowplow/prospect/testData.ts
+++ b/src/snowplow/prospect/testData.ts
@@ -22,7 +22,7 @@ export const testProspectData = {
   title: 'A tale of two cities',
   isSyndicated: true,
   isCollection: false,
-  authors: 'Charles Dickens, Mark Twain',
+  authors: 'Mark Twain, John Bon Jovi',
   prospectReviewStatus: ProspectReviewStatus.Dismissed,
   // The LDAP string of the curator who reviewed this prospect - for now, only dismissing prospect.
   reviewedBy: 'user|ldap',

--- a/src/snowplow/prospect/testData.ts
+++ b/src/snowplow/prospect/testData.ts
@@ -1,4 +1,31 @@
-import { ProspectReviewStatus } from './types';
+export const eventBridgeTestPayload = {
+  prospect: {
+    id: '123-abc',
+    prospectId: '456-cde',
+    scheduledSurfaceGuid: 'NEW_TAB_EN_US',
+    topic: 'ENTERTAINMENT',
+    prospectType: 'GLOBAL',
+    url: 'https://www.test.com/a-story',
+    saveCount: 333,
+    rank: 222,
+    curated: false,
+    createdAt: 160000000,
+    domain: 'test.com',
+    excerpt: 'Once upon a time...',
+    imageUrl: 'https://www.test.com/a-story.jpg',
+    language: 'EN',
+    publisher: 'Test.com',
+    title: 'A very interesting story',
+    isSyndicated: false,
+    isCollection: false,
+    authors: 'Mark Twain, John Bon Jovi',
+    prospectReviewStatus: 'dismissed',
+    reviewedBy: 'test-user|ldap-something',
+    reviewedAt: 1600000,
+  },
+  eventType: 'prospect-dismiss',
+  object_version: 'new',
+};
 
 export const testProspectData = {
   // a GUID we generate prior to inserting into dynamo
@@ -23,7 +50,7 @@ export const testProspectData = {
   isSyndicated: true,
   isCollection: false,
   authors: 'Mark Twain, John Bon Jovi',
-  prospectReviewStatus: ProspectReviewStatus.Dismissed,
+  prospectReviewStatus: 'dismissed',
   // The LDAP string of the curator who reviewed this prospect - for now, only dismissing prospect.
   reviewedBy: 'user|ldap',
   // The Unix timestamp in seconds.

--- a/src/snowplow/prospect/types.ts
+++ b/src/snowplow/prospect/types.ts
@@ -24,7 +24,7 @@ export type Prospect = {
   authors?: string;
   approvedCorpusItem?: { url: string };
   rejectedCorpusItem?: { url: string };
-  prospectReviewStatus: ProspectReviewStatus;
+  prospectReviewStatus: string;
   // The LDAP string of the curator who reviewed this prospect - for now, only dismissing prospect.
   reviewedBy?: string;
   // The Unix timestamp in seconds.
@@ -57,12 +57,4 @@ export type ObjectUpdate = {
 //snowplow event type
 export enum EventType {
   PROSPECT_REVIEWED = 'PROSPECT_REVIEWED',
-}
-
-export enum ProspectReviewStatus {
-  Created = 'created',
-  Recommendation = 'recommendation',
-  Corpus = 'corpus',
-  Rejected = 'rejected',
-  Dismissed = 'dismissed',
 }


### PR DESCRIPTION
## Goal
when a single SQS subscribes to both dismiss-prospect and user-events topic, the SQS only listens to the first subscribed topic and ignores the second one (assuming DLQ would also act in the same way and we might risk losing all the second and following subscription). 
removing `user-events` shouldn't affect us as its already being emitted to snowplow by user-api

### So we decided to 
- have only one subscription for the SQS in this repo to unblock dismiss prospect

other changes:
 - made prospectStatus from enum to string, easier to forward it to downstream snowplow object and expecting this to be verified by the prospect-api

### Follow-up plan:
- have a follow-up plan to test this theory for multiple subscription for a single SQS.
- set alerts for DLQ along this snowplow pipeline
- make sure SNS cannot be deleted if they have an attached target (event bridge rule prevents destroy when subscribed, does SNS do this one too?)
follow-up ticket: https://getpocket.atlassian.net/browse/INFRA-794

Ticket: https://getpocket.atlassian.net/browse/BACK-1679

TODOs:
- [ ] dev is pointing to dev ecs but prod is not pointing to prod ecs url (although we are setting it as lambda env variable). likely require a lambda deployment. after merging to prod, please verify the ecs endpoint is pointing to readitlater.com...if not, please fetch the url from ssm

dev testing: [https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Fec[…]252F8ae3cb2855824efbbcbb25a1743cb43f](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Fecs$252FSharedSnowplowConsumer-Dev$252Fapp20221011002022854900000002/log-events/ecs$252Fapp$252F8ae3cb2855824efbbcbb25a1743cb43f)

logs when dismissing from dev curated corpus UI: https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Fecs$252FSharedSnowplowConsumer-Dev$252Fapp20221011002022854900000002/log-events/ecs$252Fapp$252F8ae3cb2855824efbbcbb25a1743cb43f