### PR TITLE
Infra 837/create alert

### DIFF
--- a/.aws/package.json
+++ b/.aws/package.json
@@ -13,7 +13,7 @@
     "test": "echo ok"
   },
   "engines": {
-    "node": "=12"
+    "node": "=16"
   },
   "dependencies": {
     "@pocket-tools/terraform-modules": "4.4.0"


### PR DESCRIPTION
## Goal
Add an alert for Dead Letter Queue.

## Implementation Decisions
Kept it all in same stack class since we have no reason to reuse here atm.

## Deployment steps
Merge to dev, merge to prod.

### dev plan

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # aws_appautoscaling_target.sharedsnowplowconsumer_sharedsnowplowconsumerapp_application_autoscaling_autoscalingtarget_2C024D15 will be updated in-place
  ~ resource "aws_appautoscaling_target" "sharedsnowplowconsumer_sharedsnowplowconsumerapp_application_autoscaling_autoscalingtarget_2C024D15" {
        id                 = "service/SharedSnowplowConsumer-Dev/SharedSnowplowConsumer-Dev"
      ~ role_arn           = "arn:aws:iam::410318598490:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService" -> "arn:aws:iam::410318598490:role/SharedSnowplowConsumer-Dev-AutoScalingRole"
        # (5 unchanged attributes hidden)
    }

  # aws_cloudwatch_metric_alarm.sharedsnowplowconsumer_sharedsnowplowconsumerdevdlqalarm_DBB9B591 will be created
  + resource "aws_cloudwatch_metric_alarm" "sharedsnowplowconsumer_sharedsnowplowconsumerdevdlqalarm_DBB9B591" {
      + actions_enabled                       = true
      + alarm_description                     = "Number of messages >= 15"
      + alarm_name                            = "SharedSnowplowConsumer-Dev-SharedSnowplowConsumer-Dev-Dlq-Alarm"
      + arn                                   = (known after apply)
      + comparison_operator                   = "GreaterThanOrEqualToThreshold"
      + dimensions                            = {
          + "QueueName" = "SharedSnowplowConsumer-Dev-SNS-Topics-DLQ"
        }
      + evaluate_low_sample_count_percentiles = (known after apply)
      + evaluation_periods                    = 2
      + id                                    = (known after apply)
      + metric_name                           = "ApproximateNumberOfMessagesVisible"
      + namespace                             = "AWS/SQS"
      + period                                = 900
      + statistic                             = "Sum"
      + tags_all                              = (known after apply)
      + threshold                             = 15
      + treat_missing_data                    = "missing"
    }

  # local_file.sharedsnowplowconsumer_sharedsnowplowconsumerapp_application_ecsservice_appspec_4BE1752E will be created
  + resource "local_file" "sharedsnowplowconsumer_sharedsnowplowconsumerapp_application_ecsservice_appspec_4BE1752E" {
      + content              = jsonencode(
            {
              + Resources = [
                  + {
                      + TargetService = {
                          + Properties = {
                              + LoadBalancerInfo = {
                                  + ContainerName = "app"
                                  + ContainerPort = 4015
                                }
                              + TaskDefinition   = "arn:aws:ecs:us-east-1:410318598490:task-definition/SharedSnowplowConsumer-Dev:28"
                            }
                          + Type       = "AWS::ECS::Service"
                        }
                    },
                ]
              + version   = 1
            }
        )
      + directory_permission = "0777"
      + file_permission      = "0777"
      + filename             = "appspec.json"
      + id                   = (known after apply)
    }

  # null_resource.sharedsnowplowconsumer_sharedsnowplowconsumerapp_application_ecsservice_createtaskdefinitionfile_49CEE999 must be replaced
-/+ resource "null_resource" "sharedsnowplowconsumer_sharedsnowplowconsumerapp_application_ecsservice_createtaskdefinitionfile_49CEE999" {
      ~ id       = "1807730592260224570" -> (known after apply)
      ~ triggers = {
          - "alwaysRun" = "2023-02-03T05:51:58Z"
        } -> (known after apply) # forces replacement
    }

Plan: 3 to add, 1 to change, 1 to destroy.
╷
│ Warning: Deprecated Resource
│ 
│   with data.aws_subnet_ids.sharedsnowplowconsumer_sharedsnowplowconsumerapp_application_pocketvpc_privatesubnetids_D5720548,
│   on cdk.tf.json line 557, in data.aws_subnet_ids.sharedsnowplowconsumer_sharedsnowplowconsumerapp_application_pocketvpc_privatesubnetids_D5720548:
│  557:       },
│ 
│ The aws_subnet_ids data source has been deprecated and will be removed in a future version. Use the aws_subnets data source instead.
│ 
│ (and 3 more similar warnings elsewhere)
╵
╷
│ Warning: Argument is deprecated
│ 
│   with aws_s3_bucket.sharedsnowplowconsumer_sharedsnowplowconsumerapp_codepipeline_codepipelinebucket_CC7CE415,
│   on cdk.tf.json line 1644, in resource.aws_s3_bucket.sharedsnowplowconsumer_sharedsnowplowconsumerapp_codepipeline_codepipelinebucket_CC7CE415:
│ 1644:         "acl": "private",
│ 
│ Use the aws_s3_bucket_acl resource instead
│ 
│ (and one more similar warning elsewhere)
```

### prod plan 
(picks up a lot of stuff in dev & not yet in main/prod)

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place
  - destroy
-/+ destroy and then create replacement
 <= read (data resources)

Terraform will perform the following actions:

  # data.aws_iam_policy_document.sharedsnowplowconsumer_sharedsnowplowconsumerapp_application_ecsservice_ecsiam_dataecstaskrolepolicy_5D96F504 will be read during apply
  # (config refers to values not yet known)
 <= data "aws_iam_policy_document" "sharedsnowplowconsumer_sharedsnowplowconsumerapp_application_ecsservice_ecsiam_dataecstaskrolepolicy_5D96F504"  {
      + id      = (known after apply)
      + json    = (known after apply)
      + version = "2012-10-17"

      + statement {
          + actions   = [
              + "xray:GetSamplingRules",
              + "xray:GetSamplingStatisticSummaries",
              + "xray:GetSamplingTargets",
              + "xray:PutTelemetryRecords",
              + "xray:PutTraceSegments",
            ]
          + effect    = "Allow"
          + resources = [
              + "*",
            ]
        }
      + statement {
          + actions   = [
              + "sqs:DeleteMessage",
              + "sqs:ReceiveMessage",
              + "sqs:SendMessage",
              + "sqs:SendMessageBatch",
            ]
          + resources = [
              + "arn:aws:sqs:us-east-1:996905175585:SharedSnowplowConsumer-Prod-SNS-Topics-DLQ",
              + (known after apply),
            ]
        }
    }

  # data.aws_iam_policy_document.sharedsnowplowconsumer_sharedsnowplowconsumersnssqspolicydocument_7B173485 will be read during apply
  # (config refers to values not yet known)
 <= data "aws_iam_policy_document" "sharedsnowplowconsumer_sharedsnowplowconsumersnssqspolicydocument_7B173485"  {
      + id   = (known after apply)
      + json = (known after apply)

      + statement {
          + actions   = [
              + "sqs:SendMessage",
            ]
          + effect    = "Allow"
          + resources = [
              + (known after apply),
            ]

          + condition {
              + test     = "ArnLike"
              + values   = [
                  + "arn:aws:sns:us-east-1:996905175585:PocketEventBridge-Prod-UserEventTopic",
                  + "arn:aws:sns:us-east-1:996905175585:PocketEventBridge-Prod-ProspectEventTopic",
                ]
              + variable = "aws:SourceArn"
            }

          + principals {
              + identifiers = [
                  + "sns.amazonaws.com",
                ]
              + type        = "Service"
            }
        }
    }

  # aws_appautoscaling_target.sharedsnowplowconsumer_sharedsnowplowconsumerapp_application_autoscaling_autoscalingtarget_2C024D15 will be updated in-place
  ~ resource "aws_appautoscaling_target" "sharedsnowplowconsumer_sharedsnowplowconsumerapp_application_autoscaling_autoscalingtarget_2C024D15" {
        id                 = "service/SharedSnowplowConsumer-Prod/SharedSnowplowConsumer-Prod"
      ~ role_arn           = "arn:aws:iam::996905175585:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService" -> "arn:aws:iam::996905175585:role/SharedSnowplowConsumer-Prod-AutoScalingRole"
        # (5 unchanged attributes hidden)
    }

  # aws_cloudwatch_log_group.sharedsnowplowconsumer_sharedeventconsumer_lambda_loggroup_6C143FB5 will be destroyed
  # (because aws_cloudwatch_log_group.sharedsnowplowconsumer_sharedeventconsumer_lambda_loggroup_6C143FB5 is not in configuration)
  - resource "aws_cloudwatch_log_group" "sharedsnowplowconsumer_sharedeventconsumer_lambda_loggroup_6C143FB5" {
      - arn               = "arn:aws:logs:us-east-1:996905175585:log-group:/aws/lambda/SharedSnowplowConsumer-Prod-SharedEventConsumer-Function" -> null
      - id                = "/aws/lambda/SharedSnowplowConsumer-Prod-SharedEventConsumer-Function" -> null
      - name              = "/aws/lambda/SharedSnowplowConsumer-Prod-SharedEventConsumer-Function" -> null
      - retention_in_days = 14 -> null
      - tags              = {} -> null
      - tags_all          = {} -> null
    }

  # aws_cloudwatch_metric_alarm.sharedsnowplowconsumer_sharedsnowplowconsumerproddlqalarm_F1ADA322 will be created
  + resource "aws_cloudwatch_metric_alarm" "sharedsnowplowconsumer_sharedsnowplowconsumerproddlqalarm_F1ADA322" {
      + actions_enabled                       = true
      + alarm_actions                         = [
          + "arn:aws:sns:us-east-1:996905175585:SharedSnowplowConsumer-Prod-Infrastructure-Alarm-Non-Critical",
        ]
      + alarm_description                     = "Number of messages >= 15"
      + alarm_name                            = "SharedSnowplowConsumer-Prod-SharedSnowplowConsumer-Prod-Dlq-Alarm"
      + arn                                   = (known after apply)
      + comparison_operator                   = "GreaterThanOrEqualToThreshold"
      + dimensions                            = {
          + "QueueName" = "SharedSnowplowConsumer-Prod-SNS-Topics-DLQ"
        }
      + evaluate_low_sample_count_percentiles = (known after apply)
      + evaluation_periods                    = 2
      + id                                    = (known after apply)
      + metric_name                           = "ApproximateNumberOfMessagesVisible"
      + namespace                             = "AWS/SQS"
      + ok_actions                            = [
          + "arn:aws:sns:us-east-1:996905175585:SharedSnowplowConsumer-Prod-Infrastructure-Alarm-Non-Critical",
        ]
      + period                                = 900
      + statistic                             = "Sum"
      + tags_all                              = (known after apply)
      + threshold                             = 15
      + treat_missing_data                    = "missing"
    }

  # aws_codedeploy_app.sharedsnowplowconsumer_sharedeventconsumer_lambdacodedeploy_codedeployapp_FC50A7CB will be destroyed
  # (because aws_codedeploy_app.sharedsnowplowconsumer_sharedeventconsumer_lambdacodedeploy_codedeployapp_FC50A7CB is not in configuration)
  - resource "aws_codedeploy_app" "sharedsnowplowconsumer_sharedeventconsumer_lambdacodedeploy_codedeployapp_FC50A7CB" {
      - application_id   = "07b69b24-a3e4-490b-90ba-5be8dcbcb5f0" -> null
      - arn              = "arn:aws:codedeploy:us-east-1:996905175585:application:SharedSnowplowConsumer-Prod-SharedEventConsumer-Lambda" -> null
      - compute_platform = "Lambda" -> null
      - id               = "07b69b24-a3e4-490b-90ba-5be8dcbcb5f0:SharedSnowplowConsumer-Prod-SharedEventConsumer-Lambda" -> null
      - linked_to_github = false -> null
      - name             = "SharedSnowplowConsumer-Prod-SharedEventConsumer-Lambda" -> null
      - tags             = {} -> null
      - tags_all         = {} -> null
    }

  # aws_codedeploy_deployment_group.sharedsnowplowconsumer_sharedeventconsumer_lambdacodedeploy_codedeploymentgroup_992FEAF2 will be destroyed
  # (because aws_codedeploy_deployment_group.sharedsnowplowconsumer_sharedeventconsumer_lambdacodedeploy_codedeploymentgroup_992FEAF2 is not in configuration)
  - resource "aws_codedeploy_deployment_group" "sharedsnowplowconsumer_sharedeventconsumer_lambdacodedeploy_codedeploymentgroup_992FEAF2" {
      - app_name               = "SharedSnowplowConsumer-Prod-SharedEventConsumer-Lambda" -> null
      - arn                    = "arn:aws:codedeploy:us-east-1:996905175585:deploymentgroup:SharedSnowplowConsumer-Prod-SharedEventConsumer-Lambda/SharedSnowplowConsumer-Prod-SharedEventConsumer-Lambda" -> null
      - autoscaling_groups     = [] -> null
      - compute_platform       = "Lambda" -> null
      - deployment_config_name = "CodeDeployDefault.LambdaAllAtOnce" -> null
      - deployment_group_id    = "c2a6a0ee-17b4-4eb6-8d5f-437e1f74f0a5" -> null
      - deployment_group_name  = "SharedSnowplowConsumer-Prod-SharedEventConsumer-Lambda" -> null
      - id                     = "c2a6a0ee-17b4-4eb6-8d5f-437e1f74f0a5" -> null
      - service_role_arn       = "arn:aws:iam::996905175585:role/SharedSnowplowConsumer-Prod-SharedEventConsumer-CodeDeployRole" -> null
      - tags                   = {} -> null
      - tags_all               = {} -> null

      - auto_rollback_configuration {
          - enabled = true -> null
          - events  = [
              - "DEPLOYMENT_FAILURE",
            ] -> null
        }

      - deployment_style {
          - deployment_option = "WITH_TRAFFIC_CONTROL" -> null
          - deployment_type   = "BLUE_GREEN" -> null
        }
    }

  # aws_ecs_task_definition.sharedsnowplowconsumer_sharedsnowplowconsumerapp_application_ecsservice_ecstask_A9613D7A must be replaced
-/+ resource "aws_ecs_task_definition" "sharedsnowplowconsumer_sharedsnowplowconsumerapp_application_ecsservice_ecstask_A9613D7A" {
      ~ arn                      = "arn:aws:ecs:us-east-1:996905175585:task-definition/SharedSnowplowConsumer-Prod:3" -> (known after apply)
      ~ container_definitions    = jsonencode(
            [
              - {
                  - cpu                    = 0
                  - environment            = [
                      - {
                          - name  = "NODE_ENV"
                          - value = "production"
                        },
                      - {
                          - name  = "SNOWPLOW_ENDPOINT"
                          - value = "com-getpocket-prod1.collector.snplow.net"
                        },
                    ]
                  - essential              = true
                  - healthCheck            = {
                      - command     = [
                          - "CMD-SHELL",
                          - "curl -f http://localhost:4015/health || exit 1",
                        ]
                      - interval    = 15
                      - retries     = 3
                      - startPeriod = 0
                      - timeout     = 5
                    }
                  - image                  = "996905175585.dkr.ecr.us-east-1.amazonaws.com/sharedsnowplowconsumer-prod-app:latest"
                  - logConfiguration       = {
                      - logDriver     = "awslogs"
                      - options       = {
                          - awslogs-group         = "/ecs/SharedSnowplowConsumer-Prod/app20221012152838930600000002"
                          - awslogs-region        = "us-east-1"
                          - awslogs-stream-prefix = "ecs"
                        }
                      - secretOptions = []
                    }
                  - mountPoints            = []
                  - name                   = "app"
                  - portMappings           = [
                      - {
                          - containerPort = 4015
                          - hostPort      = 4015
                          - protocol      = "tcp"
                        },
                    ]
                  - readonlyRootFilesystem = false
                  - secrets                = [
                      - {
                          - name      = "SENTRY_DSN"
                          - valueFrom = "arn:aws:ssm:us-east-1:996905175585:parameter/SharedSnowplowConsumer/Prod/SENTRY_DSN"
                        },
                    ]
                  - volumesFrom            = []
                },
              - {
                  - command                = [
                      - "--region",
                      - "us-east-1",
                      - "--local-mode",
                    ]
                  - cpu                    = 0
                  - environment            = []
                  - essential              = true
                  - image                  = "amazon/aws-xray-daemon"
                  - logConfiguration       = {
                      - logDriver     = "awslogs"
                      - options       = {
                          - awslogs-group         = "/ecs/SharedSnowplowConsumer-Prod/xray-daemon20221012152839513900000006"
                          - awslogs-region        = "us-east-1"
                          - awslogs-stream-prefix = "ecs"
                        }
                      - secretOptions = []
                    }
                  - mountPoints            = []
                  - name                   = "xray-daemon"
                  - portMappings           = [
                      - {
                          - containerPort = 2000
                          - hostPort      = 2000
                          - protocol      = "udp"
                        },
                    ]
                  - readonlyRootFilesystem = false
                  - repositoryCredentials  = {
                      - credentialsParameter = "arn:aws:secretsmanager:us-east-1:996905175585:secret:Shared/DockerHub"
                    }
                  - volumesFrom            = []
                },
            ]
        ) -> (known after apply) # forces replacement
      ~ id                       = "SharedSnowplowConsumer-Prod" -> (known after apply)
      ~ revision                 = 3 -> (known after apply)
        tags                     = {
            "environment" = "Prod"
            "service"     = "SharedSnowplowConsumer"
        }
        # (9 unchanged attributes hidden)
    }

  # aws_iam_policy.sharedsnowplowconsumer_sharedeventconsumer_lambda_executionpolicy_95AA8A23 will be destroyed
  # (because aws_iam_policy.sharedsnowplowconsumer_sharedeventconsumer_lambda_executionpolicy_95AA8A23 is not in configuration)
  - resource "aws_iam_policy" "sharedsnowplowconsumer_sharedeventconsumer_lambda_executionpolicy_95AA8A23" {
      - arn       = "arn:aws:iam::996905175585:policy/SharedSnowplowConsumer-Prod-SharedEventConsumer-ExecutionRolePolicy" -> null
      - id        = "arn:aws:iam::996905175585:policy/SharedSnowplowConsumer-Prod-SharedEventConsumer-ExecutionRolePolicy" -> null
      - name      = "SharedSnowplowConsumer-Prod-SharedEventConsumer-ExecutionRolePolicy" -> null
      - path      = "/" -> null
      - policy    = jsonencode(
            {
              - Statement = [
                  - {
                      - Action   = [
                          - "logs:PutLogEvents",
                          - "logs:DescribeLogStreams",
                          - "logs:CreateLogStream",
                          - "logs:CreateLogGroup",
                        ]
                      - Effect   = "Allow"
                      - Resource = "arn:aws:logs:*:*:*"
                      - Sid      = ""
                    },
                  - {
                      - Action   = [
                          - "ec2:DescribeNetworkInterfaces",
                          - "ec2:DescribeInstances",
                          - "ec2:DeleteNetworkInterface",
                          - "ec2:CreateNetworkInterface",
                          - "ec2:AttachNetworkInterface",
                        ]
                      - Effect   = "Allow"
                      - Resource = "*"
                      - Sid      = ""
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> null
      - policy_id = "ANPA6QHBNZIQ2EZLGLTH5" -> null
      - tags      = {} -> null
      - tags_all  = {} -> null
    }

  # aws_iam_policy.sharedsnowplowconsumer_sharedeventconsumer_sqspolicy_AB41A6CD will be destroyed
  # (because aws_iam_policy.sharedsnowplowconsumer_sharedeventconsumer_sqspolicy_AB41A6CD is not in configuration)
  - resource "aws_iam_policy" "sharedsnowplowconsumer_sharedeventconsumer_sqspolicy_AB41A6CD" {
      - arn       = "arn:aws:iam::996905175585:policy/SharedSnowplowConsumer-Prod-SharedEventConsumer-LambdaSQSPolicy" -> null
      - id        = "arn:aws:iam::996905175585:policy/SharedSnowplowConsumer-Prod-SharedEventConsumer-LambdaSQSPolicy" -> null
      - name      = "SharedSnowplowConsumer-Prod-SharedEventConsumer-LambdaSQSPolicy" -> null
      - path      = "/" -> null
      - policy    = jsonencode(
            {
              - Statement = [
                  - {
                      - Action   = [
                          - "sqs:SendMessage",
                          - "sqs:ReceiveMessage",
                          - "sqs:GetQueueAttributes",
                          - "sqs:DeleteMessage",
                          - "sqs:ChangeMessageVisibility",
                        ]
                      - Effect   = "Allow"
                      - Resource = "arn:aws:sqs:us-east-1:996905175585:SharedSnowplowConsumer-Prod-SharedEventConsumer-Queue"
                      - Sid      = ""
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> null
      - policy_id = "ANPA6QHBNZIQ5JXJ4N7PV" -> null
      - tags      = {} -> null
      - tags_all  = {} -> null
    }

  # aws_iam_policy.sharedsnowplowconsumer_sharedsnowplowconsumerapp_application_ecsservice_ecsiam_ecstaskrolepolicy_59B7678B will be updated in-place
  ~ resource "aws_iam_policy" "sharedsnowplowconsumer_sharedsnowplowconsumerapp_application_ecsservice_ecsiam_ecstaskrolepolicy_59B7678B" {
        id        = "arn:aws:iam::996905175585:policy/SharedSnowplowConsumer-Prod-TaskRolePolicy"
        name      = "SharedSnowplowConsumer-Prod-TaskRolePolicy"
      ~ policy    = jsonencode(
            {
              - Statement = [
                  - {
                      - Action   = [
                          - "xray:PutTraceSegments",
                          - "xray:PutTelemetryRecords",
                          - "xray:GetSamplingTargets",
                          - "xray:GetSamplingStatisticSummaries",
                          - "xray:GetSamplingRules",
                        ]
                      - Effect   = "Allow"
                      - Resource = "*"
                      - Sid      = ""
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> (known after apply)
        tags      = {}
        # (4 unchanged attributes hidden)
    }

  # aws_iam_role.sharedsnowplowconsumer_sharedeventconsumer_lambda_executionrole_04216FCF will be destroyed
  # (because aws_iam_role.sharedsnowplowconsumer_sharedeventconsumer_lambda_executionrole_04216FCF is not in configuration)
  - resource "aws_iam_role" "sharedsnowplowconsumer_sharedeventconsumer_lambda_executionrole_04216FCF" {
      - arn                   = "arn:aws:iam::996905175585:role/SharedSnowplowConsumer-Prod-SharedEventConsumer-ExecutionRole" -> null
      - assume_role_policy    = jsonencode(
            {
              - Statement = [
                  - {
                      - Action    = "sts:AssumeRole"
                      - Effect    = "Allow"
                      - Principal = {
                          - Service = [
                              - "edgelambda.amazonaws.com",
                              - "lambda.amazonaws.com",
                            ]
                        }
                      - Sid       = ""
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> null
      - create_date           = "2022-09-01T15:55:54Z" -> null
      - force_detach_policies = false -> null
      - id                    = "SharedSnowplowConsumer-Prod-SharedEventConsumer-ExecutionRole" -> null
      - managed_policy_arns   = [
          - "arn:aws:iam::996905175585:policy/SharedSnowplowConsumer-Prod-SharedEventConsumer-ExecutionRolePolicy",
          - "arn:aws:iam::996905175585:policy/SharedSnowplowConsumer-Prod-SharedEventConsumer-LambdaSQSPolicy",
        ] -> null
      - max_session_duration  = 3600 -> null
      - name                  = "SharedSnowplowConsumer-Prod-SharedEventConsumer-ExecutionRole" -> null
      - path                  = "/" -> null
      - tags                  = {} -> null
      - tags_all              = {} -> null
      - unique_id             = "AROA6QHBNZIQ3HPKREFTB" -> null

      - inline_policy {}
    }

  # aws_iam_role.sharedsnowplowconsumer_sharedeventconsumer_lambdacodedeploy_codedeployrole_200D4A61 will be destroyed
  # (because aws_iam_role.sharedsnowplowconsumer_sharedeventconsumer_lambdacodedeploy_codedeployrole_200D4A61 is not in configuration)
  - resource "aws_iam_role" "sharedsnowplowconsumer_sharedeventconsumer_lambdacodedeploy_codedeployrole_200D4A61" {
      - arn                   = "arn:aws:iam::996905175585:role/SharedSnowplowConsumer-Prod-SharedEventConsumer-CodeDeployRole" -> null
      - assume_role_policy    = jsonencode(
            {
              - Statement = [
                  - {
                      - Action    = "sts:AssumeRole"
                      - Effect    = "Allow"
                      - Principal = {
                          - Service = "codedeploy.amazonaws.com"
                        }
                      - Sid       = ""
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> null
      - create_date           = "2022-09-01T15:55:54Z" -> null
      - force_detach_policies = false -> null
      - id                    = "SharedSnowplowConsumer-Prod-SharedEventConsumer-CodeDeployRole" -> null
      - managed_policy_arns   = [
          - "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda",
        ] -> null
      - max_session_duration  = 3600 -> null
      - name                  = "SharedSnowplowConsumer-Prod-SharedEventConsumer-CodeDeployRole" -> null
      - path                  = "/" -> null
      - tags                  = {} -> null
      - tags_all              = {} -> null
      - unique_id             = "AROA6QHBNZIQSVTUVPVPE" -> null

      - inline_policy {}
    }

  # aws_iam_role_policy_attachment.sharedsnowplowconsumer_sharedeventconsumer_executionrolepolicyattachment_4CC2B676 will be destroyed
  # (because aws_iam_role_policy_attachment.sharedsnowplowconsumer_sharedeventconsumer_executionrolepolicyattachment_4CC2B676 is not in configuration)
  - resource "aws_iam_role_policy_attachment" "sharedsnowplowconsumer_sharedeventconsumer_executionrolepolicyattachment_4CC2B676" {
      - id         = "SharedSnowplowConsumer-Prod-SharedEventConsumer-ExecutionRole-20220901155645576400000003" -> null
      - policy_arn = "arn:aws:iam::996905175585:policy/SharedSnowplowConsumer-Prod-SharedEventConsumer-LambdaSQSPolicy" -> null
      - role       = "SharedSnowplowConsumer-Prod-SharedEventConsumer-ExecutionRole" -> null
    }

  # aws_iam_role_policy_attachment.sharedsnowplowconsumer_sharedeventconsumer_lambda_executionrolepolicyattachment_3C365650 will be destroyed
  # (because aws_iam_role_policy_attachment.sharedsnowplowconsumer_sharedeventconsumer_lambda_executionrolepolicyattachment_3C365650 is not in configuration)
  - resource "aws_iam_role_policy_attachment" "sharedsnowplowconsumer_sharedeventconsumer_lambda_executionrolepolicyattachment_3C365650" {
      - id         = "SharedSnowplowConsumer-Prod-SharedEventConsumer-ExecutionRole-20220901155555583800000002" -> null
      - policy_arn = "arn:aws:iam::996905175585:policy/SharedSnowplowConsumer-Prod-SharedEventConsumer-ExecutionRolePolicy" -> null
      - role       = "SharedSnowplowConsumer-Prod-SharedEventConsumer-ExecutionRole" -> null
    }

  # aws_iam_role_policy_attachment.sharedsnowplowconsumer_sharedeventconsumer_lambdacodedeploy_codedeploypolicyattachment_3C486F02 will be destroyed
  # (because aws_iam_role_policy_attachment.sharedsnowplowconsumer_sharedeventconsumer_lambdacodedeploy_codedeploypolicyattachment_3C486F02 is not in configuration)
  - resource "aws_iam_role_policy_attachment" "sharedsnowplowconsumer_sharedeventconsumer_lambdacodedeploy_codedeploypolicyattachment_3C486F02" {
      - id         = "SharedSnowplowConsumer-Prod-SharedEventConsumer-CodeDeployRole-20220901155555575900000001" -> null
      - policy_arn = "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda" -> null
      - role       = "SharedSnowplowConsumer-Prod-SharedEventConsumer-CodeDeployRole" -> null
    }

  # aws_lambda_alias.sharedsnowplowconsumer_sharedeventconsumer_lambda_alias_C7EC1EC8 will be destroyed
  # (because aws_lambda_alias.sharedsnowplowconsumer_sharedeventconsumer_lambda_alias_C7EC1EC8 is not in configuration)
  - resource "aws_lambda_alias" "sharedsnowplowconsumer_sharedeventconsumer_lambda_alias_C7EC1EC8" {
      - arn              = "arn:aws:lambda:us-east-1:996905175585:function:SharedSnowplowConsumer-Prod-SharedEventConsumer-Function:DEPLOYED" -> null
      - function_name    = "SharedSnowplowConsumer-Prod-SharedEventConsumer-Function" -> null
      - function_version = "11" -> null
      - id               = "arn:aws:lambda:us-east-1:996905175585:function:SharedSnowplowConsumer-Prod-SharedEventConsumer-Function:DEPLOYED" -> null
      - invoke_arn       = "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:996905175585:function:SharedSnowplowConsumer-Prod-SharedEventConsumer-Function:DEPLOYED/invocations" -> null
      - name             = "DEPLOYED" -> null
    }

  # aws_lambda_event_source_mapping.sharedsnowplowconsumer_sharedeventconsumer_lambdaeventsourcemapping_3999265C will be destroyed
  # (because aws_lambda_event_source_mapping.sharedsnowplowconsumer_sharedeventconsumer_lambdaeventsourcemapping_3999265C is not in configuration)
  - resource "aws_lambda_event_source_mapping" "sharedsnowplowconsumer_sharedeventconsumer_lambdaeventsourcemapping_3999265C" {
      - batch_size                         = 5 -> null
      - bisect_batch_on_function_error     = false -> null
      - enabled                            = true -> null
      - event_source_arn                   = "arn:aws:sqs:us-east-1:996905175585:SharedSnowplowConsumer-Prod-SharedEventConsumer-Queue" -> null
      - function_arn                       = "arn:aws:lambda:us-east-1:996905175585:function:SharedSnowplowConsumer-Prod-SharedEventConsumer-Function:DEPLOYED" -> null
      - function_name                      = "arn:aws:lambda:us-east-1:996905175585:function:SharedSnowplowConsumer-Prod-SharedEventConsumer-Function:DEPLOYED" -> null
      - function_response_types            = [
          - "ReportBatchItemFailures",
        ] -> null
      - id                                 = "00b51980-ef65-4268-957a-0c2dd57afcb3" -> null
      - last_modified                      = "2022-09-01T15:57:01Z" -> null
      - maximum_batching_window_in_seconds = 0 -> null
      - maximum_record_age_in_seconds      = 0 -> null
      - maximum_retry_attempts             = 0 -> null
      - parallelization_factor             = 0 -> null
      - queues                             = [] -> null
      - state                              = "Enabled" -> null
      - state_transition_reason            = "USER_INITIATED" -> null
      - topics                             = [] -> null
      - tumbling_window_in_seconds         = 0 -> null
      - uuid                               = "00b51980-ef65-4268-957a-0c2dd57afcb3" -> null
    }

  # aws_lambda_function.sharedsnowplowconsumer_sharedeventconsumer_lambda_47C8F046 will be destroyed
  # (because aws_lambda_function.sharedsnowplowconsumer_sharedeventconsumer_lambda_47C8F046 is not in configuration)
  - resource "aws_lambda_function" "sharedsnowplowconsumer_sharedeventconsumer_lambda_47C8F046" {
      - architectures                  = [
          - "x86_64",
        ] -> null
      - arn                            = "arn:aws:lambda:us-east-1:996905175585:function:SharedSnowplowConsumer-Prod-SharedEventConsumer-Function" -> null
      - code_signing_config_arn        = "" -> null
      - description                    = "" -> null
      - filename                       = "index.js.zip" -> null
      - function_name                  = "SharedSnowplowConsumer-Prod-SharedEventConsumer-Function" -> null
      - handler                        = "index.handler" -> null
      - id                             = "SharedSnowplowConsumer-Prod-SharedEventConsumer-Function" -> null
      - image_uri                      = "" -> null
      - invoke_arn                     = "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:996905175585:function:SharedSnowplowConsumer-Prod-SharedEventConsumer-Function/invocations" -> null
      - kms_key_arn                    = "" -> null
      - last_modified                  = "2023-01-11T16:55:23.000+0000" -> null
      - layers                         = [] -> null
      - memory_size                    = 128 -> null
      - package_type                   = "Zip" -> null
      - publish                        = true -> null
      - qualified_arn                  = "arn:aws:lambda:us-east-1:996905175585:function:SharedSnowplowConsumer-Prod-SharedEventConsumer-Function:19" -> null
      - reserved_concurrent_executions = 10 -> null
      - role                           = "arn:aws:iam::996905175585:role/SharedSnowplowConsumer-Prod-SharedEventConsumer-ExecutionRole" -> null
      - runtime                        = "nodejs16.x" -> null
      - signing_job_arn                = "" -> null
      - signing_profile_version_arn    = "" -> null
      - source_code_hash               = "m7FOnkNrO+aLTfpUFR+ljdsc0qCoTlFs63V9XGhcTog=" -> null
      - source_code_size               = 33846835 -> null
      - tags                           = {
          - "environment" = "Prod"
          - "service"     = "SharedSnowplowConsumer"
        } -> null
      - tags_all                       = {
          - "environment" = "Prod"
          - "service"     = "SharedSnowplowConsumer"
        } -> null
      - timeout                        = 300 -> null
      - version                        = "19" -> null

      - environment {
          - variables = {
              - "ECS_ENDPOINT" = "https://shared-snowplow-consumer.readitlater.com"
              - "ENVIRONMENT"  = "production"
              - "GIT_SHA"      = (sensitive)
              - "SENTRY_DSN"   = (sensitive)
            } -> null
        }

      - ephemeral_storage {
          - size = 512 -> null
        }

      - tracing_config {
          - mode = "PassThrough" -> null
        }

      - vpc_config {
          - security_group_ids = [
              - "sg-2efb704a",
            ] -> null
          - subnet_ids         = [
              - "subnet-610bdb3b",
              - "subnet-b2a036fa",
              - "subnet-cc66bde0",
              - "subnet-d09eb8ec",
            ] -> null
          - vpc_id             = "vpc-867638e3" -> null
        }
    }

  # aws_s3_bucket.sharedsnowplowconsumer_sharedeventconsumer_lambda_codebucket_C73778B9 will be destroyed
  # (because aws_s3_bucket.sharedsnowplowconsumer_sharedeventconsumer_lambda_codebucket_C73778B9 is not in configuration)
  - resource "aws_s3_bucket" "sharedsnowplowconsumer_sharedeventconsumer_lambda_codebucket_C73778B9" {
      - acl                         = "private" -> null
      - arn                         = "arn:aws:s3:::pocket-sharedsnowplowconsumer-prod-sharedeventconsumer" -> null
      - bucket                      = "pocket-sharedsnowplowconsumer-prod-sharedeventconsumer" -> null
      - bucket_domain_name          = "pocket-sharedsnowplowconsumer-prod-sharedeventconsumer.s3.amazonaws.com" -> null
      - bucket_regional_domain_name = "pocket-sharedsnowplowconsumer-prod-sharedeventconsumer.s3.amazonaws.com" -> null
      - force_destroy               = true -> null
      - hosted_zone_id              = "Z3AQBSTGFYJSTF" -> null
      - id                          = "pocket-sharedsnowplowconsumer-prod-sharedeventconsumer" -> null
      - object_lock_enabled         = false -> null
      - region                      = "us-east-1" -> null
      - request_payer               = "BucketOwner" -> null
      - tags                        = {
          - "environment" = "Prod"
          - "service"     = "SharedSnowplowConsumer"
        } -> null
      - tags_all                    = {
          - "environment" = "Prod"
          - "service"     = "SharedSnowplowConsumer"
        } -> null

      - grant {
          - id          = "92f1efb5501a01f6ebb8e3628131c3483688d3e5ca1a7c175420c565a06a6616" -> null
          - permissions = [
              - "FULL_CONTROL",
            ] -> null
          - type        = "CanonicalUser" -> null
        }

      - versioning {
          - enabled    = false -> null
          - mfa_delete = false -> null
        }
    }

  # aws_s3_bucket_public_access_block.sharedsnowplowconsumer_sharedeventconsumer_lambda_codebucketpublicaccessblock_6A5C5715 will be destroyed
  # (because aws_s3_bucket_public_access_block.sharedsnowplowconsumer_sharedeventconsumer_lambda_codebucketpublicaccessblock_6A5C5715 is not in configuration)
  - resource "aws_s3_bucket_public_access_block" "sharedsnowplowconsumer_sharedeventconsumer_lambda_codebucketpublicaccessblock_6A5C5715" {
      - block_public_acls       = true -> null
      - block_public_policy     = true -> null
      - bucket                  = "pocket-sharedsnowplowconsumer-prod-sharedeventconsumer" -> null
      - id                      = "pocket-sharedsnowplowconsumer-prod-sharedeventconsumer" -> null
      - ignore_public_acls      = false -> null
      - restrict_public_buckets = false -> null
    }

  # aws_sns_topic_subscription.sharedsnowplowconsumer_ProspectEventTopicsnssubscription_2458C879 must be replaced
-/+ resource "aws_sns_topic_subscription" "sharedsnowplowconsumer_ProspectEventTopicsnssubscription_2458C879" {
      ~ arn                             = "arn:aws:sns:us-east-1:996905175585:PocketEventBridge-Prod-ProspectEventTopic:e17e7515-d981-45d8-a0cb-4d96bb63218d" -> (known after apply)
      ~ confirmation_was_authenticated  = true -> (known after apply)
      ~ endpoint                        = "arn:aws:sqs:us-east-1:996905175585:SharedSnowplowConsumer-Prod-SharedEventConsumer-Queue" -> (known after apply) # forces replacement
      ~ id                              = "arn:aws:sns:us-east-1:996905175585:PocketEventBridge-Prod-ProspectEventTopic:e17e7515-d981-45d8-a0cb-4d96bb63218d" -> (known after apply)
      ~ owner_id                        = "996905175585" -> (known after apply)
      ~ pending_confirmation            = false -> (known after apply)
        # (6 unchanged attributes hidden)
    }

  # aws_sns_topic_subscription.sharedsnowplowconsumer_UserEventTopicsnssubscription_1C26EFDB must be replaced
-/+ resource "aws_sns_topic_subscription" "sharedsnowplowconsumer_UserEventTopicsnssubscription_1C26EFDB" {
      ~ arn                             = "arn:aws:sns:us-east-1:996905175585:PocketEventBridge-Prod-UserEventTopic:48164758-c8f5-46b9-a09d-a692fb078c43" -> (known after apply)
      ~ confirmation_was_authenticated  = true -> (known after apply)
      ~ endpoint                        = "arn:aws:sqs:us-east-1:996905175585:SharedSnowplowConsumer-Prod-SharedEventConsumer-Queue" -> (known after apply) # forces replacement
      ~ id                              = "arn:aws:sns:us-east-1:996905175585:PocketEventBridge-Prod-UserEventTopic:48164758-c8f5-46b9-a09d-a692fb078c43" -> (known after apply)
      ~ owner_id                        = "996905175585" -> (known after apply)
      ~ pending_confirmation            = false -> (known after apply)
        # (6 unchanged attributes hidden)
    }

  # aws_sqs_queue.sharedsnowplowconsumer_sharedeventconsumer_AF5395FB will be created
  + resource "aws_sqs_queue" "sharedsnowplowconsumer_sharedeventconsumer_AF5395FB" {
      + arn                               = (known after apply)
      + content_based_deduplication       = false
      + deduplication_scope               = (known after apply)
      + delay_seconds                     = 0
      + fifo_queue                        = false
      + fifo_throughput_limit             = (known after apply)
      + id                                = (known after apply)
      + kms_data_key_reuse_period_seconds = (known after apply)
      + max_message_size                  = 262144
      + message_retention_seconds         = 345600
      + name                              = "SharedSnowplowConsumer-Prod-SharedEventConsumer-Queue"
      + name_prefix                       = (known after apply)
      + policy                            = (known after apply)
      + receive_wait_time_seconds         = 0
      + tags                              = {
          + "environment" = "Prod"
          + "service"     = "SharedSnowplowConsumer"
        }
      + tags_all                          = {
          + "environment" = "Prod"
          + "service"     = "SharedSnowplowConsumer"
        }
      + url                               = (known after apply)
      + visibility_timeout_seconds        = 30
    }

  # aws_sqs_queue.sharedsnowplowconsumer_sharedeventconsumer_lambdasqsqueue_47CCA09E will be destroyed
  # (because aws_sqs_queue.sharedsnowplowconsumer_sharedeventconsumer_lambdasqsqueue_47CCA09E is not in configuration)
  - resource "aws_sqs_queue" "sharedsnowplowconsumer_sharedeventconsumer_lambdasqsqueue_47CCA09E" {
      - arn                               = "arn:aws:sqs:us-east-1:996905175585:SharedSnowplowConsumer-Prod-SharedEventConsumer-Queue" -> null
      - content_based_deduplication       = false -> null
      - delay_seconds                     = 0 -> null
      - fifo_queue                        = false -> null
      - id                                = "https://sqs.us-east-1.amazonaws.com/996905175585/SharedSnowplowConsumer-Prod-SharedEventConsumer-Queue" -> null
      - kms_data_key_reuse_period_seconds = 300 -> null
      - max_message_size                  = 262144 -> null
      - message_retention_seconds         = 345600 -> null
      - name                              = "SharedSnowplowConsumer-Prod-SharedEventConsumer-Queue" -> null
      - policy                            = jsonencode(
            {
              - Statement = [
                  - {
                      - Action    = "sqs:SendMessage"
                      - Condition = {
                          - ArnLike = {
                              - aws:SourceArn = [
                                  - "arn:aws:sns:us-east-1:996905175585:PocketEventBridge-Prod-UserEventTopic",
                                  - "arn:aws:sns:us-east-1:996905175585:PocketEventBridge-Prod-ProspectEventTopic",
                                ]
                            }
                        }
                      - Effect    = "Allow"
                      - Principal = {
                          - Service = "sns.amazonaws.com"
                        }
                      - Resource  = "arn:aws:sqs:us-east-1:996905175585:SharedSnowplowConsumer-Prod-SharedEventConsumer-Queue"
                      - Sid       = ""
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> null
      - receive_wait_time_seconds         = 0 -> null
      - redrive_policy                    = jsonencode(
            {
              - deadLetterTargetArn = "arn:aws:sqs:us-east-1:996905175585:SharedSnowplowConsumer-Prod-SharedEventConsumer-Queue-Deadletter"
              - maxReceiveCount     = 3
            }
        ) -> null
      - sqs_managed_sse_enabled           = false -> null
      - tags                              = {
          - "environment" = "Prod"
          - "service"     = "SharedSnowplowConsumer"
        } -> null
      - tags_all                          = {
          - "environment" = "Prod"
          - "service"     = "SharedSnowplowConsumer"
        } -> null
      - url                               = "https://sqs.us-east-1.amazonaws.com/996905175585/SharedSnowplowConsumer-Prod-SharedEventConsumer-Queue" -> null
      - visibility_timeout_seconds        = 300 -> null
    }

  # aws_sqs_queue.sharedsnowplowconsumer_sharedeventconsumer_lambdasqsqueue_redrivesqsqueue_F6895825 will be destroyed
  # (because aws_sqs_queue.sharedsnowplowconsumer_sharedeventconsumer_lambdasqsqueue_redrivesqsqueue_F6895825 is not in configuration)
  - resource "aws_sqs_queue" "sharedsnowplowconsumer_sharedeventconsumer_lambdasqsqueue_redrivesqsqueue_F6895825" {
      - arn                               = "arn:aws:sqs:us-east-1:996905175585:SharedSnowplowConsumer-Prod-SharedEventConsumer-Queue-Deadletter" -> null
      - content_based_deduplication       = false -> null
      - delay_seconds                     = 0 -> null
      - fifo_queue                        = false -> null
      - id                                = "https://sqs.us-east-1.amazonaws.com/996905175585/SharedSnowplowConsumer-Prod-SharedEventConsumer-Queue-Deadletter" -> null
      - kms_data_key_reuse_period_seconds = 300 -> null
      - max_message_size                  = 262144 -> null
      - message_retention_seconds         = 345600 -> null
      - name                              = "SharedSnowplowConsumer-Prod-SharedEventConsumer-Queue-Deadletter" -> null
      - receive_wait_time_seconds         = 0 -> null
      - sqs_managed_sse_enabled           = false -> null
      - tags                              = {
          - "environment" = "Prod"
          - "service"     = "SharedSnowplowConsumer"
        } -> null
      - tags_all                          = {
          - "environment" = "Prod"
          - "service"     = "SharedSnowplowConsumer"
        } -> null
      - url                               = "https://sqs.us-east-1.amazonaws.com/996905175585/SharedSnowplowConsumer-Prod-SharedEventConsumer-Queue-Deadletter" -> null
      - visibility_timeout_seconds        = 30 -> null
    }

  # aws_sqs_queue_policy.sharedsnowplowconsumer_sharedsnowplowconsumersnssqspolicy_944A153E must be replaced
-/+ resource "aws_sqs_queue_policy" "sharedsnowplowconsumer_sharedsnowplowconsumersnssqspolicy_944A153E" {
      ~ id        = "https://sqs.us-east-1.amazonaws.com/996905175585/SharedSnowplowConsumer-Prod-SharedEventConsumer-Queue" -> (known after apply)
      ~ policy    = jsonencode(
            {
              - Statement = [
                  - {
                      - Action    = "sqs:SendMessage"
                      - Condition = {
                          - ArnLike = {
                              - aws:SourceArn = [
                                  - "arn:aws:sns:us-east-1:996905175585:PocketEventBridge-Prod-UserEventTopic",
                                  - "arn:aws:sns:us-east-1:996905175585:PocketEventBridge-Prod-ProspectEventTopic",
                                ]
                            }
                        }
                      - Effect    = "Allow"
                      - Principal = {
                          - Service = "sns.amazonaws.com"
                        }
                      - Resource  = "arn:aws:sqs:us-east-1:996905175585:SharedSnowplowConsumer-Prod-SharedEventConsumer-Queue"
                      - Sid       = ""
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> (known after apply)
      ~ queue_url = "https://sqs.us-east-1.amazonaws.com/996905175585/SharedSnowplowConsumer-Prod-SharedEventConsumer-Queue" -> (known after apply) # forces replacement
    }

  # local_file.sharedsnowplowconsumer_sharedsnowplowconsumerapp_application_ecsservice_appspec_4BE1752E will be created
  + resource "local_file" "sharedsnowplowconsumer_sharedsnowplowconsumerapp_application_ecsservice_appspec_4BE1752E" {
      + content              = (known after apply)
      + directory_permission = "0777"
      + file_permission      = "0777"
      + filename             = "appspec.json"
      + id                   = (known after apply)
    }

  # null_resource.sharedsnowplowconsumer_sharedsnowplowconsumerapp_application_ecsservice_createtaskdefinitionfile_49CEE999 must be replaced
-/+ resource "null_resource" "sharedsnowplowconsumer_sharedsnowplowconsumerapp_application_ecsservice_createtaskdefinitionfile_49CEE999" {
      ~ id       = "6658301741162280952" -> (known after apply)
      ~ triggers = {
          - "alwaysRun" = "2023-01-11T16:55:23Z"
        } -> (known after apply) # forces replacement
    }

Plan: 8 to add, 2 to change, 22 to destroy.
╷
│ Warning: Deprecated Resource
│ 
│   with data.aws_subnet_ids.sharedsnowplowconsumer_sharedsnowplowconsumerapp_application_pocketvpc_privatesubnetids_D5720548,
│   on cdk.tf.json line 557, in data.aws_subnet_ids.sharedsnowplowconsumer_sharedsnowplowconsumerapp_application_pocketvpc_privatesubnetids_D5720548:
│  557:       },
│ 
│ The aws_subnet_ids data source has been deprecated and will be removed in a future version. Use the aws_subnets data source instead.
│ 
│ (and 3 more similar warnings elsewhere)
╵
╷
│ Warning: Argument is deprecated
│ 
│   with aws_s3_bucket.sharedsnowplowconsumer_sharedsnowplowconsumerapp_codepipeline_codepipelinebucket_CC7CE415,
│   on cdk.tf.json line 1646, in resource.aws_s3_bucket.sharedsnowplowconsumer_sharedsnowplowconsumerapp_codepipeline_codepipelinebucket_CC7CE415:
│ 1646:         "acl": "private",
│ 
│ Use the aws_s3_bucket_acl resource instead
│ 
│ (and one more similar warning elsewhere)
╵
```

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/INFRA-837
