### PR TITLE
feat(collectionEvents): [INFRA-999] consume and publish collection events

### DIFF
--- a/.aws/src/config/index.ts
+++ b/.aws/src/config/index.ts
@@ -56,6 +56,7 @@ export const config = {
     prospectEventTopic: 'ProspectEventTopic',
     shareableListEventTopic: 'ShareableListEventTopic',
     shareableListItemEventTopic: 'ShareableListItemEventTopic',
+    collectionEventTopic: 'CollectionEventTopic',
   },
   envVars: {
     snowplowEndpoint: snowplowEndpoint,

--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -101,12 +101,22 @@ class SnowplowSharedConsumerStack extends TerraformStack {
       config.eventBridge.shareableListItemEventTopic
     );
 
+    // Consumer Queue should be able to listen to collection-created and collection-updated events from collection-api.
+    const collectionEventTopicArn = `arn:aws:sns:${region.name}:${caller.accountId}:${config.eventBridge.prefix}-${config.environment}-${config.eventBridge.collectionEventTopic}`;
+    this.subscribeSqsToSnsTopic(
+      sqsConsumeQueue,
+      snsTopicDlq,
+      collectionEventTopicArn,
+      config.eventBridge.collectionEventTopic
+    );
+
     // Add additional event subscriptions here.
     const SNSTopicsSubscriptionList = [
       userEventTopicArn,
       prospectEventTopicArn,
       shareableListEventTopicArn,
       shareableListItemEventTopicArn,
+      collectionEventTopicArn,
     ];
 
     // Assigns inline access policy for SQS and DLQ.

--- a/README.md
+++ b/README.md
@@ -3,31 +3,34 @@
 shared consumer for consuming from event-bridge and emitting to snowplow.
 ![Architecture](snowplow.png)
 
-Architecutre diagram: https://miro.com/app/board/uXjVO5oHq_U=/
+Architecture diagram: https://miro.com/app/board/uXjVO5oHq_U=/
 
 ## Folder structure
-- the infrastructure code is present in `.aws`
-  - the SQS should be able to listen to the SNS/eventBridge rule that you want to onboard
 
-  
+- the infrastructure code is present in `.aws`
+  - the SQS should be able to listen to the SNS/eventBridge rule that you want to onboard.
 - the ECS application code is in `src`. This sends the event to snowplow.
-  - the `sqsConsumer` contains logic to consume from the SQS queue
-  - the `eventConsumer` contains logic to consume from event-bridge and transform them to snowplow
-  - the `snowplow` folder contains handlers to send events to snowplow
-- `.docker` contains local setup
-- `.circleci` contains circleCI setup
+  - the `sqsConsumer` contains logic to consume from the SQS queue.
+  - the `eventConsumer` contains logic to consume from event-bridge and transform them to snowplow.
+  - the `snowplow` folder contains handlers to send events to snowplow.
+- `.docker` contains local setup.
+- `.circleci` contains circleCI setup.
 
 ## How to onboard a new event?
+
 - in `.aws`, add the SNS arn to `SNSTopicsSubscriptionList`
 - in `eventConsumer`, please map the event-bridge payload to your snowplow format.
-- in `snowplow` folder, please construct your snowplow payload as per your schema model
-  - Make sure the schema version in `config.schema` that matches with dev/prod snowplow version
+- in `snowplow` folder, please construct your snowplow payload as per your schema model.
+  - Make sure the schema version in `config.schema` that matches with dev/prod snowplow version.
 
 ### Note:
+
 - any event going through event-bridge has to be idempotent, and the consumer should be able to handle duplicate events in-case we replay the events.
-- please check with #support-data-analytics if the model can tolerate duplicate events before onboarding events to this repo
+- please check with #support-data-analytics to make sure which event triggers to use for the `object_update` event.
+- please check with #support-data-analytics if the model can tolerate duplicate events before onboarding events to this repo.
 
 ## Develop Locally
+
 ```bash
 nvm use
 npm ci
@@ -35,6 +38,7 @@ npm start:dev
 ```
 
 ## To run test for ecs
+
 ```bash
 npm ci
 npm run test
@@ -42,6 +46,7 @@ npm run test-integrations
 ```
 
 ## Start docker
+
 ```bash
 # npm ci not required if already up-to-date
 npm ci

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -52,18 +52,12 @@ export const config = {
     retries: 3,
     appId: 'pocket-snowplow-consumer',
     events: EventType,
-    schemas: {
-      account: 'iglu:com.pocket/account/jsonschema/1-0-2',
-      objectUpdate: 'iglu:com.pocket/object_update/jsonschema/1-0-9',
-      user: 'iglu:com.pocket/user/jsonschema/1-0-0',
-      apiUser: 'iglu:com.pocket/api_user/jsonschema/1-0-0',
-      prospect: 'iglu:com.pocket/prospect/jsonschema/1-0-0',
-    },
     appIds: {
       //todo: make the event bridge event to send this
       //or convert from event bridge's source
       prospectApi: 'pocket-prospect-api',
       userApi: 'pocket-user-api',
+      collectionApi: 'pocket-collection-api',
     },
   },
 };

--- a/src/eventConsumer/collectionEvents/collectionEventConsumer.spec.ts
+++ b/src/eventConsumer/collectionEvents/collectionEventConsumer.spec.ts
@@ -13,7 +13,7 @@ describe('getCollectionEventPayload', () => {
     const requestBody = {
       'detail-type': 'collection-created',
       source: 'collection-created',
-      detail: testCollectionData,
+      detail: { collection: testCollectionData },
     };
 
     const payload = getCollectionEventPayload(requestBody);
@@ -30,7 +30,7 @@ describe('getCollectionEventPayload', () => {
     const requestBody = {
       'detail-type': 'collection-updated',
       source: 'collection-updated',
-      detail: testCollectionData,
+      detail: { collection: testCollectionData },
     };
 
     const payload = getCollectionEventPayload(requestBody);

--- a/src/eventConsumer/collectionEvents/collectionEventConsumer.spec.ts
+++ b/src/eventConsumer/collectionEvents/collectionEventConsumer.spec.ts
@@ -1,0 +1,39 @@
+import { getCollectionEventPayload } from './collectionEventConsumer';
+import { CollectionEventPayloadSnowplow } from '../../snowplow/collection/types';
+import { testCollectionData } from '../../snowplow/collection/testData';
+
+describe('getCollectionEventPayload', () => {
+  it('should convert collection created event request body to Collection', () => {
+    const collectionCreatedEvent: CollectionEventPayloadSnowplow = {
+      object_version: 'new',
+      collection: testCollectionData,
+      eventType: 'COLLECTION_CREATED',
+    };
+
+    const requestBody = {
+      'detail-type': 'collection-created',
+      source: 'collection-created',
+      detail: testCollectionData,
+    };
+
+    const payload = getCollectionEventPayload(requestBody);
+    expect(payload).toEqual(collectionCreatedEvent);
+  });
+
+  it('should convert collection updated event request body to Collection', () => {
+    const collectionUpdatedEvent: CollectionEventPayloadSnowplow = {
+      object_version: 'new',
+      collection: testCollectionData,
+      eventType: 'COLLECTION_UPDATED',
+    };
+
+    const requestBody = {
+      'detail-type': 'collection-updated',
+      source: 'collection-updated',
+      detail: testCollectionData,
+    };
+
+    const payload = getCollectionEventPayload(requestBody);
+    expect(payload).toEqual(collectionUpdatedEvent);
+  });
+});

--- a/src/eventConsumer/collectionEvents/collectionEventConsumer.ts
+++ b/src/eventConsumer/collectionEvents/collectionEventConsumer.ts
@@ -30,7 +30,9 @@ export function getCollectionEventPayload(
   const eventPayload: CollectionEventBusPayload = eventObj['detail'];
   const detailType = eventObj['detail-type'];
   return {
-    collection: eventPayload,
+    //todo @herraj: refactor as part of chores ticket
+    //and validate events from event-bridge
+    collection: eventPayload['collection'],
     object_version: 'new',
     eventType: DetailTypeToSnowplowMap[detailType],
   };

--- a/src/eventConsumer/collectionEvents/collectionEventConsumer.ts
+++ b/src/eventConsumer/collectionEvents/collectionEventConsumer.ts
@@ -1,0 +1,37 @@
+import {
+  EventTypeString,
+  Collection,
+  CollectionEventPayloadSnowplow,
+} from '../../snowplow/collection/types';
+import { CollectionEventHandler } from '../../snowplow/collection/collectionEventHandler';
+
+// Collection events detail-type in event rule defined in the pocket-event-bridge repo
+// see here .aws/src/event-rules/collection-events/eventConfig.ts
+export const DetailTypeToSnowplowMap: Record<string, EventTypeString> = {
+  'collection-created': 'COLLECTION_CREATED',
+  'collection-updated': 'COLLECTION_UPDATED',
+};
+
+//event bridge payload for Collection
+export type CollectionEventBusPayload = Collection;
+
+export function collectionEventConsumer(requestBody: any) {
+  new CollectionEventHandler().process(getCollectionEventPayload(requestBody));
+}
+
+/**
+ * converts the event-bridge event format to snowplow payload
+ * for a Collection event
+ * @param eventObj event bridge event format
+ */
+export function getCollectionEventPayload(
+  eventObj: any
+): CollectionEventPayloadSnowplow {
+  const eventPayload: CollectionEventBusPayload = eventObj['detail'];
+  const detailType = eventObj['detail-type'];
+  return {
+    collection: eventPayload,
+    object_version: 'new',
+    eventType: DetailTypeToSnowplowMap[detailType],
+  };
+}

--- a/src/eventConsumer/index.ts
+++ b/src/eventConsumer/index.ts
@@ -1,5 +1,6 @@
 import { userEventConsumer } from './userEvents/userEventConsumer';
 import { prospectEventConsumer } from './prospectEvents/prospectEventConsumer';
+import { collectionEventConsumer } from './collectionEvents/collectionEventConsumer';
 
 //any types shared between events can be added here
 
@@ -8,6 +9,8 @@ export enum EventType {
   ACCOUNT_DELETION = 'account-deletion',
   ACCOUNT_EMAIL_UPDATED = 'account-email-updated',
   PROSPECT_DISMISS = 'prospect-dismiss',
+  COLLECTION_CREATED = 'collection-created',
+  COLLECTION_UPDATED = 'collection-updated',
 }
 
 // Mapping of detail-type (via event bridge message)
@@ -18,4 +21,6 @@ export const eventConsumer: {
   [EventType.ACCOUNT_DELETION]: userEventConsumer,
   [EventType.ACCOUNT_EMAIL_UPDATED]: userEventConsumer,
   [EventType.PROSPECT_DISMISS]: prospectEventConsumer,
+  [EventType.COLLECTION_CREATED]: collectionEventConsumer,
+  [EventType.COLLECTION_UPDATED]: collectionEventConsumer,
 };

--- a/src/snowplow/collection/collectionEventHandler.ts
+++ b/src/snowplow/collection/collectionEventHandler.ts
@@ -1,0 +1,125 @@
+import { buildSelfDescribingEvent } from '@snowplow/node-tracker';
+import { SelfDescribingJson } from '@snowplow/tracker-core';
+import {
+  CollectionEventPayloadSnowplow,
+  CollectionStatus,
+  CollectionLanguage,
+  ObjectUpdate,
+  SnowplowEventMap,
+  CollectionAuthor,
+  CollectionPartnership,
+  CollectionStory,
+  CurationCategory,
+  IABChildCategory,
+  IABParentCategory,
+  Label,
+  collectionEventSchema,
+} from './types';
+import { config } from '../../config';
+import { EventHandler } from '../EventHandler';
+import { getTracker } from '../tracker';
+
+type ObjectUpdateEvent = Omit<SelfDescribingJson, 'data'> & {
+  data: ObjectUpdate;
+};
+
+type CollectionContext = Omit<SelfDescribingJson, 'data'> & {
+  data: {
+    object_version: string;
+    collection_id: string;
+    slug: string;
+    status: CollectionStatus;
+    title: string;
+    excerpt: string;
+    labels: [Label];
+    intro: string;
+    image_url: string;
+    authors: [CollectionAuthor];
+    iab_parent_category: IABParentCategory;
+    language: CollectionLanguage;
+    curation_category: CurationCategory;
+    partnership: CollectionPartnership;
+    stories: [CollectionStory];
+    published_at: number;
+    created_at: number;
+    updated_at: number;
+    iab_child_category: IABChildCategory;
+  };
+};
+
+/**
+ * class to send `collection-event` to snowplow
+ */
+export class CollectionEventHandler extends EventHandler {
+  constructor() {
+    const tracker = getTracker(config.snowplow.appIds.collectionApi);
+    super(tracker);
+    return this;
+  }
+
+  /**
+   * method to create and process event data
+   * @param data
+   */
+  process(data: CollectionEventPayloadSnowplow): void {
+    const event = buildSelfDescribingEvent({
+      event: CollectionEventHandler.generateCollectionEvent(data),
+    });
+    const context = CollectionEventHandler.generateEventContext(data);
+    super.addToTrackerQueue(event, context);
+  }
+
+  /**
+   * Builds the Snowplow object_update event object. Extracts the event trigger type from the received payload.
+   * Two possible trigger values are: collection_created and collection_updated
+   */
+  private static generateCollectionEvent(
+    data: CollectionEventPayloadSnowplow
+  ): ObjectUpdateEvent {
+    return {
+      schema: collectionEventSchema.objectUpdate,
+      data: {
+        trigger: SnowplowEventMap[data.eventType],
+        object: 'collection',
+      },
+    };
+  }
+
+  private static generateEventContext(
+    data: CollectionEventPayloadSnowplow
+  ): SelfDescribingJson[] {
+    return [CollectionEventHandler.generateSnowplowCollectionEvent(data)];
+  }
+
+  /**
+   * Static method to generate an object that maps properties received in the event payload object to the snowplow collection object schema.
+   */
+  private static generateSnowplowCollectionEvent(
+    data: CollectionEventPayloadSnowplow
+  ): CollectionContext {
+    return {
+      schema: collectionEventSchema.collection,
+      data: {
+        object_version: 'new',
+        collection_id: data.collection.externalId,
+        slug: data.collection.slug,
+        status: data.collection.status,
+        title: data.collection.title,
+        excerpt: data.collection.excerpt,
+        labels: data.collection.labels,
+        intro: data.collection.intro,
+        image_url: data.collection.imageUrl,
+        authors: data.collection.authors,
+        iab_parent_category: data.collection.IABParentCategory,
+        language: data.collection.language,
+        curation_category: data.collection.curationCategory,
+        partnership: data.collection.partnership,
+        stories: data.collection.stories,
+        published_at: data.collection.publishedAt,
+        created_at: data.collection.createdAt,
+        updated_at: data.collection.updatedAt,
+        iab_child_category: data.collection.IABChildCategory,
+      },
+    };
+  }
+}

--- a/src/snowplow/collection/collectionEventHandler.ts
+++ b/src/snowplow/collection/collectionEventHandler.ts
@@ -31,15 +31,15 @@ type CollectionContext = Omit<SelfDescribingJson, 'data'> & {
     status: CollectionStatus;
     title: string;
     excerpt: string;
-    labels: [Label];
+    labels: Label[];
     intro: string;
     image_url: string;
-    authors: [CollectionAuthor];
+    authors: CollectionAuthor[];
     iab_parent_category: IABParentCategory;
     language: CollectionLanguage;
     curation_category: CurationCategory;
     partnership: CollectionPartnership;
-    stories: [CollectionStory];
+    stories: CollectionStory[];
     published_at: number;
     created_at: number;
     updated_at: number;
@@ -65,7 +65,8 @@ export class CollectionEventHandler extends EventHandler {
     const event = buildSelfDescribingEvent({
       event: CollectionEventHandler.generateCollectionEvent(data),
     });
-    const context = CollectionEventHandler.generateEventContext(data);
+    const context: SelfDescribingJson[] =
+      CollectionEventHandler.generateEventContext(data);
     super.addToTrackerQueue(event, context);
   }
 
@@ -97,7 +98,7 @@ export class CollectionEventHandler extends EventHandler {
   private static generateSnowplowCollectionEvent(
     data: CollectionEventPayloadSnowplow
   ): CollectionContext {
-    return {
+    const snowplowEvent = {
       schema: collectionEventSchema.collection,
       data: {
         object_version: 'new',
@@ -121,5 +122,6 @@ export class CollectionEventHandler extends EventHandler {
         iab_child_category: data.collection.IABChildCategory,
       },
     };
+    return snowplowEvent;
   }
 }

--- a/src/snowplow/collection/testData.ts
+++ b/src/snowplow/collection/testData.ts
@@ -1,0 +1,94 @@
+import {
+  Collection,
+  CollectionAuthor,
+  CollectionLanguage,
+  CollectionStatus,
+  CollectionStory,
+  CollectionStoryAuthor,
+  CollectionPartnership,
+  CollectionPartnershipType,
+  CurationCategory,
+  IABParentCategory,
+  IABChildCategory,
+  Label,
+} from './types';
+
+const testAuthor: CollectionAuthor = {
+  active: true,
+  bio: 'test-author-bio',
+  collection_author_id: 'test-author-id',
+  image_url: 'www.test-author-image.com',
+  name: 'testAuthor',
+  slug: 'test-author',
+};
+
+const testStoryAuthor: CollectionStoryAuthor = {
+  name: 'test-story-author',
+  sort_order: 1,
+};
+
+const testStory: CollectionStory = {
+  authors: [testStoryAuthor],
+  excerpt: 'test-story-excerpt',
+  collection_story_id: 'test-story-id',
+  is_from_partner: true,
+  image_url: 'www.test-story-image-url.com',
+  publisher: 'test-story-publisher',
+  sort_order: 1,
+  title: 'test-story-title',
+  url: 'test-story-url',
+};
+
+const testLabel: Label = {
+  collection_label_id: 'test-label-id',
+  name: 'test-label-name',
+};
+
+const testCurationCategory: CurationCategory = {
+  collection_curation_category_id: 'test-curation-category-id',
+  name: 'test-curation-category-name',
+  slug: 'test-curation-category-name',
+};
+
+const testPartnership: CollectionPartnership = {
+  blurb: 'test-partnership-blurb',
+  collection_partnership_id: 'test-partnership-id',
+  image_url: 'www.test-partnership-image.com',
+  name: 'test-partnership-name',
+  type: CollectionPartnershipType.PARTNERED,
+  url: 'www.test-partnership-url.com',
+};
+
+const IABParentCategory: IABParentCategory = {
+  collection_iab_parent_category_id: 'test-iab-category-id',
+  name: 'test-iab-category-name',
+  slug: 'test-iab-category-slug',
+};
+
+const IABChildCategory: IABChildCategory = {
+  collection_iab_child_category_id: 'test-iab-category-id',
+  name: 'test-iab-category-name',
+  slug: 'test-iab-category-slug',
+};
+
+export const testCollectionData: Collection = {
+  externalId: 'test-collection-id',
+  slug: 'test-collection-slug',
+  title: 'test-collection-title',
+  status: CollectionStatus.PUBLISHED,
+  language: CollectionLanguage.EN,
+  authors: [testAuthor],
+  stories: [testStory],
+  createdAt: 1675978338, // 2023-02-09 16:32:18
+  updatedAt: 1675978338,
+
+  imageUrl: 'www.test-collection-image.com',
+  labels: [testLabel],
+  intro: 'test-collection-intro',
+  curationCategory: testCurationCategory,
+  excerpt: 'test-collection-excerpt',
+  partnership: testPartnership,
+  publishedAt: 1675978338,
+  IABParentCategory: IABParentCategory,
+  IABChildCategory: IABChildCategory,
+};

--- a/src/snowplow/collection/types.ts
+++ b/src/snowplow/collection/types.ts
@@ -37,13 +37,13 @@ export type Collection = {
   title: string;
   status: CollectionStatus;
   language: CollectionLanguage;
-  authors: [CollectionAuthor];
-  stories: [CollectionStory];
+  authors: CollectionAuthor[];
+  stories: CollectionStory[];
   createdAt: number; // in seconds
   updatedAt: number; // in seconds
 
   imageUrl?: string;
-  labels?: [Label];
+  labels?: Label[];
   intro?: string;
   curationCategory?: CurationCategory;
   excerpt?: string;
@@ -106,7 +106,7 @@ export type CollectionStory = {
   excerpt: string;
   image_url?: string;
   publisher?: string;
-  authors: [CollectionStoryAuthor];
+  authors: CollectionStoryAuthor[];
   is_from_partner: boolean;
   sort_order?: number;
 };
@@ -127,5 +127,5 @@ export type Label = { collection_label_id: string; name: string };
 
 export const collectionEventSchema = {
   objectUpdate: 'iglu:com.pocket/object_update/jsonschema/1-0-13',
-  collection: 'iglu:com.pocket/collection/jsonschema/1-0-2',
+  collection: 'iglu:com.pocket/collection/jsonschema/1-0-3',
 };

--- a/src/snowplow/collection/types.ts
+++ b/src/snowplow/collection/types.ts
@@ -1,0 +1,131 @@
+export type BasicCollectionEventPayloadWithContext = {
+  object_version: string;
+  collection: Collection;
+};
+
+export type EventTypeString = keyof typeof EventType;
+
+export type CollectionEventPayloadSnowplow =
+  BasicCollectionEventPayloadWithContext & {
+    eventType: EventTypeString;
+  };
+
+export type SnowplowEventType = 'collection_created' | 'collection_updated';
+
+export const SnowplowEventMap: Record<EventTypeString, SnowplowEventType> = {
+  COLLECTION_CREATED: 'collection_created',
+  COLLECTION_UPDATED: 'collection_updated',
+};
+
+export type ObjectUpdate = {
+  trigger: SnowplowEventType;
+  object: 'collection';
+};
+
+export enum EventType {
+  COLLECTION_CREATED = 'COLLECTION_CREATED',
+  COLLECTION_UPDATED = 'COLLECTION_UPDATED',
+}
+
+/**
+ * This Collection type aligns with what we have in collection-api i.e the object keys are the same as the Collection type.
+ * The child types however map to the snowplow schema for the Collection object. These types should be refactored @Herraj
+ */
+export type Collection = {
+  externalId: string;
+  slug: string;
+  title: string;
+  status: CollectionStatus;
+  language: CollectionLanguage;
+  authors: [CollectionAuthor];
+  stories: [CollectionStory];
+  createdAt: number; // in seconds
+  updatedAt: number; // in seconds
+
+  imageUrl?: string;
+  labels?: [Label];
+  intro?: string;
+  curationCategory?: CurationCategory;
+  excerpt?: string;
+  partnership?: CollectionPartnership;
+  publishedAt?: number; // in seconds
+  IABParentCategory?: IABParentCategory;
+  IABChildCategory?: IABChildCategory;
+};
+
+/**
+ * All of the types below map to the sub types in the snowplow Collection schema. See the comment above for the Collection type.
+ */
+export enum CollectionLanguage {
+  DE = 'DE',
+  EN = 'EN',
+}
+
+export enum CollectionPartnershipType {
+  PARTNERED = 'PARTNERED',
+  SPONSORED = 'SPONSORED',
+}
+
+export enum CollectionStatus {
+  DRAFT = 'draft',
+  REVIEW = 'review',
+  PUBLISHED = 'published',
+  ARCHIVED = 'archived',
+}
+
+export type CollectionStoryAuthor = { name: string; sort_order: number };
+
+export type CurationCategory = {
+  collection_curation_category_id: string;
+  name: string;
+  slug: string;
+};
+
+export type CollectionPartnership = {
+  collection_partnership_id: string;
+  name: string;
+  blurb: string;
+  image_url: string;
+  type: CollectionPartnershipType;
+  url: string;
+};
+
+export type CollectionAuthor = {
+  collection_author_id: string;
+  name: string;
+  active: boolean;
+  slug?: string;
+  bio?: string;
+  image_url?: string;
+};
+
+export type CollectionStory = {
+  collection_story_id: string;
+  url: string;
+  title: string;
+  excerpt: string;
+  image_url?: string;
+  publisher?: string;
+  authors: [CollectionStoryAuthor];
+  is_from_partner: boolean;
+  sort_order?: number;
+};
+
+export type IABParentCategory = {
+  collection_iab_parent_category_id: string;
+  name: string;
+  slug: string;
+};
+
+export type IABChildCategory = {
+  collection_iab_child_category_id: string;
+  name: string;
+  slug: string;
+};
+
+export type Label = { collection_label_id: string; name: string };
+
+export const collectionEventSchema = {
+  objectUpdate: 'iglu:com.pocket/object_update/jsonschema/1-0-13',
+  collection: 'iglu:com.pocket/collection/jsonschema/1-0-2',
+};

--- a/src/snowplow/prospect/prospectEventHandler.integration.ts
+++ b/src/snowplow/prospect/prospectEventHandler.integration.ts
@@ -1,7 +1,7 @@
 import fetch from 'node-fetch';
 import { expect } from 'chai';
 import { config } from '../../config';
-import { ObjectUpdate, EventType } from './types';
+import { ObjectUpdate, EventType, prospectEventSchema } from './types';
 import { ProspectEventHandler } from './prospectEventHandler';
 import { testProspectData } from './testData';
 
@@ -38,7 +38,7 @@ function assertValidSnowplowObjectUpdateEvents(
 
   expect(parsedEvents).to.include.deep.members(
     triggers.map((trigger) => ({
-      schema: config.snowplow.schemas.objectUpdate,
+      schema: prospectEventSchema.objectUpdate,
       data: { trigger: trigger, object: 'prospect' },
     }))
   );
@@ -47,7 +47,7 @@ function assertValidSnowplowObjectUpdateEvents(
 function assertProspectSchema(eventContext) {
   expect(eventContext.data).to.include.deep.members([
     {
-      schema: config.snowplow.schemas.prospect,
+      schema: prospectEventSchema.prospect,
       data: {
         object_version: 'new',
         prospect_id: testProspectData.prospectId,

--- a/src/snowplow/prospect/prospectEventHandler.ts
+++ b/src/snowplow/prospect/prospectEventHandler.ts
@@ -3,6 +3,7 @@ import { SelfDescribingJson } from '@snowplow/tracker-core';
 import {
   ObjectUpdate,
   ProspectEventPayloadSnowplow,
+  prospectEventSchema,
   ProspectReviewStatus,
   SnowplowEventMap,
 } from './types';
@@ -67,7 +68,7 @@ export class ProspectEventHandler extends EventHandler {
     data: ProspectEventPayloadSnowplow
   ): ObjectUpdateEvent {
     return {
-      schema: config.snowplow.schemas.objectUpdate,
+      schema: prospectEventSchema.objectUpdate,
       data: {
         trigger: SnowplowEventMap[data.eventType],
         object: 'prospect',
@@ -82,7 +83,7 @@ export class ProspectEventHandler extends EventHandler {
     data: ProspectEventPayloadSnowplow
   ): ProspectContext {
     return {
-      schema: config.snowplow.schemas.prospect,
+      schema: prospectEventSchema.prospect,
       data: {
         object_version: 'new',
         prospect_id: data.prospect.prospectId,

--- a/src/snowplow/prospect/types.ts
+++ b/src/snowplow/prospect/types.ts
@@ -66,3 +66,8 @@ export enum ProspectReviewStatus {
   Rejected = 'rejected',
   Dismissed = 'dismissed',
 }
+
+export const prospectEventSchema = {
+  objectUpdate: 'iglu:com.pocket/object_update/jsonschema/1-0-9',
+  prospect: 'iglu:com.pocket/prospect/jsonschema/1-0-0',
+};

--- a/src/snowplow/user/types.ts
+++ b/src/snowplow/user/types.ts
@@ -68,3 +68,10 @@ export const SnowplowEventMap: Record<EventTypeString, SnowplowEventType> = {
   ACCOUNT_DELETE: 'account_delete',
   ACCOUNT_EMAIL_UPDATED: 'account_email_updated',
 };
+
+export const userEventsSchema = {
+  account: 'iglu:com.pocket/account/jsonschema/1-0-2',
+  objectUpdate: 'iglu:com.pocket/object_update/jsonschema/1-0-9',
+  user: 'iglu:com.pocket/user/jsonschema/1-0-0',
+  apiUser: 'iglu:com.pocket/api_user/jsonschema/1-0-0',
+};

--- a/src/snowplow/user/userEventHandler.ts
+++ b/src/snowplow/user/userEventHandler.ts
@@ -1,6 +1,11 @@
 import { buildSelfDescribingEvent } from '@snowplow/node-tracker';
 import { SelfDescribingJson } from '@snowplow/tracker-core';
-import { EventType, SnowplowEventMap, UserEventPayloadSnowplow } from './types';
+import {
+  EventType,
+  SnowplowEventMap,
+  UserEventPayloadSnowplow,
+  userEventsSchema,
+} from './types';
 import { Account, ApiUser, ObjectUpdate, User } from './types';
 import { config } from '../../config';
 import { EventHandler } from '../EventHandler';
@@ -52,7 +57,7 @@ export class UserEventHandler extends EventHandler {
     data: UserEventPayloadSnowplow
   ): ObjectUpdateEvent {
     return {
-      schema: config.snowplow.schemas.objectUpdate,
+      schema: userEventsSchema.objectUpdate,
       data: {
         trigger: SnowplowEventMap[data.eventType],
         object: 'account',
@@ -67,7 +72,7 @@ export class UserEventHandler extends EventHandler {
     data: UserEventPayloadSnowplow
   ): AccountContext {
     return {
-      schema: config.snowplow.schemas.account,
+      schema: userEventsSchema.account,
       data: {
         object_version: 'new',
         user_id: parseInt(data.user.id),
@@ -79,7 +84,7 @@ export class UserEventHandler extends EventHandler {
     data: UserEventPayloadSnowplow
   ): AccountContext {
     return {
-      schema: config.snowplow.schemas.account,
+      schema: userEventsSchema.account,
       data: {
         object_version: 'new',
         user_id: parseInt(data.user.id),
@@ -106,7 +111,7 @@ export class UserEventHandler extends EventHandler {
     data: UserEventPayloadSnowplow
   ): UserContext {
     return {
-      schema: config.snowplow.schemas.user,
+      schema: userEventsSchema.user,
       data: {
         email: data.user.email,
         guid: data.user.guid,
@@ -121,7 +126,7 @@ export class UserEventHandler extends EventHandler {
     data: UserEventPayloadSnowplow
   ): ApiUserContext {
     return {
-      schema: config.snowplow.schemas.apiUser,
+      schema: userEventsSchema.apiUser,
       data: {
         api_id: parseInt(data.apiUser.apiId),
         name: data.apiUser.name,


### PR DESCRIPTION
## Goal
Adding a snowplow event consumer for events emitted by `collection-api`. Consuming two events here, `collection-created` and `collection-updated`

- Includes changes from this PR https://github.com/Pocket/shared-snowplow-consumer/pull/173. Moves the entity schema and `object_update` schema versions into the `types.ts` of the respective backend entities (prospect / user)

Events are tested in **DEV**.

JIRA ticket:
* [INFRA-999]

[INFRA-999]: https://getpocket.atlassian.net/browse/INFRA-999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

### Follow up work: https://getpocket.atlassian.net/browse/INFRA-1114