### PR TITLE
fix(integration-test): seperate out schema for events

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - HOSTNAME_EXTERNAL=localstack
 
   snowplow:
-    image: pocket/snowplow-micro:latest
+    image: pocket/snowplow-micro:prod
     platform: linux/amd64
     ports:
       - '9090:9090'

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -54,7 +54,7 @@ export const config = {
     events: EventType,
     schemas: {
       account: 'iglu:com.pocket/account/jsonschema/1-0-2',
-      objectUpdate: 'iglu:com.pocket/object_update/jsonschema/1-0-12',
+      objectUpdate: 'iglu:com.pocket/object_update/jsonschema/1-0-10',
       user: 'iglu:com.pocket/user/jsonschema/1-0-0',
       apiUser: 'iglu:com.pocket/api_user/jsonschema/1-0-0',
       prospect: 'iglu:com.pocket/prospect/jsonschema/1-0-0',

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -52,13 +52,6 @@ export const config = {
     retries: 3,
     appId: 'pocket-snowplow-consumer',
     events: EventType,
-    schemas: {
-      account: 'iglu:com.pocket/account/jsonschema/1-0-2',
-      objectUpdate: 'iglu:com.pocket/object_update/jsonschema/1-0-10',
-      user: 'iglu:com.pocket/user/jsonschema/1-0-0',
-      apiUser: 'iglu:com.pocket/api_user/jsonschema/1-0-0',
-      prospect: 'iglu:com.pocket/prospect/jsonschema/1-0-0',
-    },
     appIds: {
       //todo: make the event bridge event to send this
       //or convert from event bridge's source

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -54,7 +54,7 @@ export const config = {
     events: EventType,
     schemas: {
       account: 'iglu:com.pocket/account/jsonschema/1-0-2',
-      objectUpdate: 'iglu:com.pocket/object_update/jsonschema/1-0-9',
+      objectUpdate: 'iglu:com.pocket/object_update/jsonschema/1-0-12',
       user: 'iglu:com.pocket/user/jsonschema/1-0-0',
       apiUser: 'iglu:com.pocket/api_user/jsonschema/1-0-0',
       prospect: 'iglu:com.pocket/prospect/jsonschema/1-0-0',

--- a/src/snowplow/prospect/prospectEventHandler.integration.ts
+++ b/src/snowplow/prospect/prospectEventHandler.integration.ts
@@ -1,7 +1,7 @@
 import fetch from 'node-fetch';
 import { expect } from 'chai';
 import { config } from '../../config';
-import { ObjectUpdate, EventType } from './types';
+import { ObjectUpdate, EventType, prospectEventSchema } from './types';
 import { ProspectEventHandler } from './prospectEventHandler';
 import { testProspectData } from './testData';
 
@@ -38,7 +38,7 @@ function assertValidSnowplowObjectUpdateEvents(
 
   expect(parsedEvents).to.include.deep.members(
     triggers.map((trigger) => ({
-      schema: config.snowplow.schemas.objectUpdate,
+      schema: prospectEventSchema.objectUpdate,
       data: { trigger: trigger, object: 'prospect' },
     }))
   );
@@ -47,7 +47,7 @@ function assertValidSnowplowObjectUpdateEvents(
 function assertProspectSchema(eventContext) {
   expect(eventContext.data).to.include.deep.members([
     {
-      schema: config.snowplow.schemas.prospect,
+      schema: prospectEventSchema.prospect,
       data: {
         object_version: 'new',
         prospect_id: testProspectData.prospectId,

--- a/src/snowplow/prospect/prospectEventHandler.ts
+++ b/src/snowplow/prospect/prospectEventHandler.ts
@@ -3,6 +3,7 @@ import { SelfDescribingJson } from '@snowplow/tracker-core';
 import {
   ObjectUpdate,
   ProspectEventPayloadSnowplow,
+  prospectEventSchema,
   ProspectReviewStatus,
   SnowplowEventMap,
 } from './types';
@@ -67,7 +68,7 @@ export class ProspectEventHandler extends EventHandler {
     data: ProspectEventPayloadSnowplow
   ): ObjectUpdateEvent {
     return {
-      schema: config.snowplow.schemas.objectUpdate,
+      schema: prospectEventSchema.objectUpdate,
       data: {
         trigger: SnowplowEventMap[data.eventType],
         object: 'prospect',
@@ -82,7 +83,7 @@ export class ProspectEventHandler extends EventHandler {
     data: ProspectEventPayloadSnowplow
   ): ProspectContext {
     return {
-      schema: config.snowplow.schemas.prospect,
+      schema: prospectEventSchema.prospect,
       data: {
         object_version: 'new',
         prospect_id: data.prospect.prospectId,

--- a/src/snowplow/prospect/types.ts
+++ b/src/snowplow/prospect/types.ts
@@ -66,3 +66,8 @@ export enum ProspectReviewStatus {
   Rejected = 'rejected',
   Dismissed = 'dismissed',
 }
+
+export const prospectEventSchema = {
+  objectUpdate: 'iglu:com.pocket/object_update/jsonschema/1-0-9',
+  prospect: 'iglu:com.pocket/prospect/jsonschema/1-0-0',
+};

--- a/src/snowplow/user/types.ts
+++ b/src/snowplow/user/types.ts
@@ -68,3 +68,10 @@ export const SnowplowEventMap: Record<EventTypeString, SnowplowEventType> = {
   ACCOUNT_DELETE: 'account_delete',
   ACCOUNT_EMAIL_UPDATED: 'account_email_updated',
 };
+
+export const userEventsSchema = {
+  account: 'iglu:com.pocket/account/jsonschema/1-0-2',
+  objectUpdate: 'iglu:com.pocket/object_update/jsonschema/1-0-9',
+  user: 'iglu:com.pocket/user/jsonschema/1-0-0',
+  apiUser: 'iglu:com.pocket/api_user/jsonschema/1-0-0',
+};

--- a/src/snowplow/user/userEventHandler.integration.ts
+++ b/src/snowplow/user/userEventHandler.integration.ts
@@ -1,7 +1,7 @@
 import fetch from 'node-fetch';
 import { expect } from 'chai';
 import { config } from '../../config';
-import { ObjectUpdate, EventType } from './types';
+import { ObjectUpdate, EventType, userEventsSchema } from './types';
 import { UserEventHandler } from './userEventHandler';
 
 async function snowplowRequest(path: string, post = false): Promise<any> {
@@ -37,7 +37,7 @@ function assertValidSnowplowObjectUpdateEvents(
 
   expect(parsedEvents).to.include.deep.members(
     triggers.map((trigger) => ({
-      schema: config.snowplow.schemas.objectUpdate,
+      schema: userEventsSchema.objectUpdate,
       data: { trigger: trigger, object: 'account' },
     }))
   );
@@ -46,7 +46,7 @@ function assertValidSnowplowObjectUpdateEvents(
 function assertAccountDeleteSchema(eventContext) {
   expect(eventContext.data).to.include.deep.members([
     {
-      schema: config.snowplow.schemas.account,
+      schema: userEventsSchema.account,
       data: {
         object_version: 'new',
         user_id: parseInt(testAccountData.id),
@@ -58,7 +58,7 @@ function assertAccountDeleteSchema(eventContext) {
 function assertAccountSchema(eventContext) {
   expect(eventContext.data).to.include.deep.members([
     {
-      schema: config.snowplow.schemas.account,
+      schema: userEventsSchema.account,
       data: {
         object_version: 'new',
         user_id: parseInt(testAccountData.id),
@@ -71,7 +71,7 @@ function assertAccountSchema(eventContext) {
 function assertApiAndUserSchema(eventContext: { [p: string]: any }) {
   expect(eventContext.data).to.include.deep.members([
     {
-      schema: config.snowplow.schemas.user,
+      schema: userEventsSchema.user,
       data: {
         user_id: parseInt(testEventData.user.id),
         hashed_user_id: testAccountData.hashedId,
@@ -79,7 +79,7 @@ function assertApiAndUserSchema(eventContext: { [p: string]: any }) {
       },
     },
     {
-      schema: config.snowplow.schemas.apiUser,
+      schema: userEventsSchema.apiUser,
       data: { api_id: parseInt(testEventData.apiUser.apiId) },
     },
   ]);

--- a/src/snowplow/user/userEventHandler.ts
+++ b/src/snowplow/user/userEventHandler.ts
@@ -1,6 +1,11 @@
 import { buildSelfDescribingEvent } from '@snowplow/node-tracker';
 import { SelfDescribingJson } from '@snowplow/tracker-core';
-import { EventType, SnowplowEventMap, UserEventPayloadSnowplow } from './types';
+import {
+  EventType,
+  SnowplowEventMap,
+  UserEventPayloadSnowplow,
+  userEventsSchema,
+} from './types';
 import { Account, ApiUser, ObjectUpdate, User } from './types';
 import { config } from '../../config';
 import { EventHandler } from '../EventHandler';
@@ -52,7 +57,7 @@ export class UserEventHandler extends EventHandler {
     data: UserEventPayloadSnowplow
   ): ObjectUpdateEvent {
     return {
-      schema: config.snowplow.schemas.objectUpdate,
+      schema: userEventsSchema.objectUpdate,
       data: {
         trigger: SnowplowEventMap[data.eventType],
         object: 'account',
@@ -67,7 +72,7 @@ export class UserEventHandler extends EventHandler {
     data: UserEventPayloadSnowplow
   ): AccountContext {
     return {
-      schema: config.snowplow.schemas.account,
+      schema: userEventsSchema.account,
       data: {
         object_version: 'new',
         user_id: parseInt(data.user.id),
@@ -79,7 +84,7 @@ export class UserEventHandler extends EventHandler {
     data: UserEventPayloadSnowplow
   ): AccountContext {
     return {
-      schema: config.snowplow.schemas.account,
+      schema: userEventsSchema.account,
       data: {
         object_version: 'new',
         user_id: parseInt(data.user.id),
@@ -106,7 +111,7 @@ export class UserEventHandler extends EventHandler {
     data: UserEventPayloadSnowplow
   ): UserContext {
     return {
-      schema: config.snowplow.schemas.user,
+      schema: userEventsSchema.user,
       data: {
         email: data.user.email,
         guid: data.user.guid,
@@ -121,7 +126,7 @@ export class UserEventHandler extends EventHandler {
     data: UserEventPayloadSnowplow
   ): ApiUserContext {
     return {
-      schema: config.snowplow.schemas.apiUser,
+      schema: userEventsSchema.apiUser,
       data: {
         api_id: parseInt(data.apiUser.apiId),
         name: data.apiUser.name,


### PR DESCRIPTION
# goal

the snowplow schema continously evolves for new events and the versions are not backward compatible

so we are making the events folder handle their schema version. this way, when we onboard new events - we don't have to actively maintain older event schema


ticket: https://getpocket.atlassian.net/browse/INFRA-1055