### PR TITLE
OSL-211: Add sns subscription for shareable-lists-api events

### DIFF
--- a/.aws/src/config/index.ts
+++ b/.aws/src/config/index.ts
@@ -54,6 +54,7 @@ export const config = {
     prefix: 'PocketEventBridge',
     userTopic: 'UserEventTopic',
     prospectEventTopic: 'ProspectEventTopic',
+    shareableListsApiEventTopic: 'ShareableListEventTopic',
   },
   envVars: {
     snowplowEndpoint: snowplowEndpoint,

--- a/.aws/src/config/index.ts
+++ b/.aws/src/config/index.ts
@@ -54,7 +54,7 @@ export const config = {
     prefix: 'PocketEventBridge',
     userTopic: 'UserEventTopic',
     prospectEventTopic: 'ProspectEventTopic',
-    shareableListsApiEventTopic: 'ShareableListEventTopic',
+    shareableListsApiEventTopic: 'ShareableListsApiEventTopic',
   },
   envVars: {
     snowplowEndpoint: snowplowEndpoint,

--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -83,10 +83,20 @@ class SnowplowSharedConsumerStack extends TerraformStack {
       config.eventBridge.prospectEventTopic
     );
 
+    // Consumer Queue should be able to listen to shareable-list and shareable-list-item events from shareable-lists-api.
+    const shareableListsApiEventTopicArn = `arn:aws:sns:${region.name}:${caller.accountId}:${config.eventBridge.prefix}-${config.environment}-${config.eventBridge.shareableListsApiEventTopic}`;
+    this.subscribeSqsToSnsTopic(
+      sqsConsumeQueue,
+      snsTopicDlq,
+      shareableListsApiEventTopicArn,
+      config.eventBridge.shareableListsApiEventTopic
+    );
+
     // Add additional event subscriptions here.
     const SNSTopicsSubscriptionList = [
       userEventTopicArn,
       prospectEventTopicArn,
+      shareableListEventTopicArn,
     ];
 
     // Assigns inline access policy for SQS and DLQ.

--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -96,7 +96,7 @@ class SnowplowSharedConsumerStack extends TerraformStack {
     const SNSTopicsSubscriptionList = [
       userEventTopicArn,
       prospectEventTopicArn,
-      shareableListEventTopicArn,
+      shareableListsApiEventTopicArn,
     ];
 
     // Assigns inline access policy for SQS and DLQ.


### PR DESCRIPTION
## Goal
Creating a SNS topic subscription for the `ShareableListsApiEventTopic` [event bridge rule](https://github.com/Pocket/pocket-event-bridge/pull/106)

JIRA ticket:
* [https://getpocket.atlassian.net/browse/OSL-211](https://getpocket.atlassian.net/browse/OSL-211)