### PR TITLE
OSL-210: consume and publish shareable-lists-api events to Snowplow

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -58,6 +58,7 @@ export const config = {
       prospectApi: 'pocket-prospect-api',
       userApi: 'pocket-user-api',
       collectionApi: 'pocket-collection-api',
+      shareableListsApi: 'pocket-shareable-lists-api',
     },
   },
 };

--- a/src/eventConsumer/index.ts
+++ b/src/eventConsumer/index.ts
@@ -1,6 +1,7 @@
 import { userEventConsumer } from './userEvents/userEventConsumer';
 import { prospectEventConsumer } from './prospectEvents/prospectEventConsumer';
 import { collectionEventConsumer } from './collectionEvents/collectionEventConsumer';
+import { shareableListEventConsumer } from './shareableListEvents/shareableListEventConsumer';
 
 //any types shared between events can be added here
 
@@ -11,6 +12,15 @@ export enum EventType {
   PROSPECT_DISMISS = 'prospect-dismiss',
   COLLECTION_CREATED = 'collection-created',
   COLLECTION_UPDATED = 'collection-updated',
+  //shareable-lists-api event types
+  SHAREABLE_LIST_CREATED = 'shareable_list_created',
+  SHAREABLE_LIST_UPDATED = 'shareable_list_updated',
+  SHAREABLE_LIST_DELETED = 'shareable_list_deleted',
+  SHAREABLE_LIST_PUBLISHED = 'shareable_list_published',
+  SHAREABLE_LIST_UNPUBLISHED = 'shareable_list_unpublished',
+  SHAREABLE_LIST_HIDDEN = 'shareable_list_hidden',
+  SHAREABLE_LIST_ITEM_CREATED = 'shareable_list_item_created',
+  SHAREABLE_LIST_ITEM_DELETED = 'shareable_list_item_deleted',
 }
 
 // Mapping of detail-type (via event bridge message)
@@ -23,4 +33,10 @@ export const eventConsumer: {
   [EventType.PROSPECT_DISMISS]: prospectEventConsumer,
   [EventType.COLLECTION_CREATED]: collectionEventConsumer,
   [EventType.COLLECTION_UPDATED]: collectionEventConsumer,
+  [EventType.SHAREABLE_LIST_CREATED]: shareableListEventConsumer,
+  [EventType.SHAREABLE_LIST_UPDATED]: shareableListEventConsumer,
+  [EventType.SHAREABLE_LIST_DELETED]: shareableListEventConsumer,
+  [EventType.SHAREABLE_LIST_PUBLISHED]: shareableListEventConsumer,
+  [EventType.SHAREABLE_LIST_UNPUBLISHED]: shareableListEventConsumer,
+  [EventType.SHAREABLE_LIST_HIDDEN]: shareableListEventConsumer,
 };

--- a/src/eventConsumer/index.ts
+++ b/src/eventConsumer/index.ts
@@ -2,6 +2,7 @@ import { userEventConsumer } from './userEvents/userEventConsumer';
 import { prospectEventConsumer } from './prospectEvents/prospectEventConsumer';
 import { collectionEventConsumer } from './collectionEvents/collectionEventConsumer';
 import { shareableListEventConsumer } from './shareableListEvents/shareableListEventConsumer';
+import { shareableListItemEventConsumer } from './shareableListItemEvents/shareableListItemEventConsumer';
 
 //any types shared between events can be added here
 
@@ -39,4 +40,6 @@ export const eventConsumer: {
   [EventType.SHAREABLE_LIST_PUBLISHED]: shareableListEventConsumer,
   [EventType.SHAREABLE_LIST_UNPUBLISHED]: shareableListEventConsumer,
   [EventType.SHAREABLE_LIST_HIDDEN]: shareableListEventConsumer,
+  [EventType.SHAREABLE_LIST_ITEM_CREATED]: shareableListItemEventConsumer,
+  [EventType.SHAREABLE_LIST_ITEM_DELETED]: shareableListItemEventConsumer,
 };

--- a/src/eventConsumer/shareableListEvents/shareableListEventConsumer.spec.ts
+++ b/src/eventConsumer/shareableListEvents/shareableListEventConsumer.spec.ts
@@ -1,0 +1,104 @@
+import { getShareableListEventPayload } from './shareableListEventConsumer';
+import {
+  EventType,
+  ShareableListEventPayloadSnowplow,
+} from '../../snowplow/shareableList/types';
+import { testShareableListData } from '../../snowplow/shareableList/testData';
+
+describe('getShareableListEventPayload', () => {
+  it('should convert shareable_list_created event request body to Snowplow ShareableList', () => {
+    const shareableListCreatedEvent: ShareableListEventPayloadSnowplow = {
+      shareable_list: testShareableListData,
+      eventType: EventType.SHAREABLE_LIST_CREATED,
+    };
+
+    const requestBody = {
+      'detail-type': 'shareable_list_created',
+      source: 'shareable-list-events',
+      detail: { shareableList: testShareableListData },
+    };
+
+    const payload = getShareableListEventPayload(requestBody);
+    expect(payload).toEqual(shareableListCreatedEvent);
+  });
+
+  it('should convert shareable_list_updated event request body to Snowplow ShareableList', () => {
+    const shareableListCreatedEvent: ShareableListEventPayloadSnowplow = {
+      shareable_list: testShareableListData,
+      eventType: EventType.SHAREABLE_LIST_UPDATED,
+    };
+
+    const requestBody = {
+      'detail-type': 'shareable_list_updated',
+      source: 'shareable-list-events',
+      detail: { shareableList: testShareableListData },
+    };
+
+    const payload = getShareableListEventPayload(requestBody);
+    expect(payload).toEqual(shareableListCreatedEvent);
+  });
+
+  it('should convert shareable_list_deleted event request body to Snowplow ShareableList', () => {
+    const shareableListCreatedEvent: ShareableListEventPayloadSnowplow = {
+      shareable_list: testShareableListData,
+      eventType: EventType.SHAREABLE_LIST_DELETED,
+    };
+
+    const requestBody = {
+      'detail-type': 'shareable_list_deleted',
+      source: 'shareable-list-events',
+      detail: { shareableList: testShareableListData },
+    };
+
+    const payload = getShareableListEventPayload(requestBody);
+    expect(payload).toEqual(shareableListCreatedEvent);
+  });
+
+  it('should convert shareable_list_published event request body to Snowplow ShareableList', () => {
+    const shareableListCreatedEvent: ShareableListEventPayloadSnowplow = {
+      shareable_list: testShareableListData,
+      eventType: EventType.SHAREABLE_LIST_PUBLISHED,
+    };
+
+    const requestBody = {
+      'detail-type': 'shareable_list_published',
+      source: 'shareable-list-events',
+      detail: { shareableList: testShareableListData },
+    };
+
+    const payload = getShareableListEventPayload(requestBody);
+    expect(payload).toEqual(shareableListCreatedEvent);
+  });
+
+  it('should convert shareable_list_unpublished event request body to Snowplow ShareableList', () => {
+    const shareableListCreatedEvent: ShareableListEventPayloadSnowplow = {
+      shareable_list: testShareableListData,
+      eventType: EventType.SHAREABLE_LIST_UNPUBLISHED,
+    };
+
+    const requestBody = {
+      'detail-type': 'shareable_list_unpublished',
+      source: 'shareable-list-events',
+      detail: { shareableList: testShareableListData },
+    };
+
+    const payload = getShareableListEventPayload(requestBody);
+    expect(payload).toEqual(shareableListCreatedEvent);
+  });
+
+  it('should convert shareable_list_hidden event request body to Snowplow ShareableList', () => {
+    const shareableListCreatedEvent: ShareableListEventPayloadSnowplow = {
+      shareable_list: testShareableListData,
+      eventType: EventType.SHAREABLE_LIST_HIDDEN,
+    };
+
+    const requestBody = {
+      'detail-type': 'shareable_list_hidden',
+      source: 'shareable-list-events',
+      detail: { shareableList: testShareableListData },
+    };
+
+    const payload = getShareableListEventPayload(requestBody);
+    expect(payload).toEqual(shareableListCreatedEvent);
+  });
+});

--- a/src/eventConsumer/shareableListEvents/shareableListEventConsumer.spec.ts
+++ b/src/eventConsumer/shareableListEvents/shareableListEventConsumer.spec.ts
@@ -3,7 +3,10 @@ import {
   EventType,
   ShareableListEventPayloadSnowplow,
 } from '../../snowplow/shareableList/types';
-import { testShareableListData } from '../../snowplow/shareableList/testData';
+import {
+  testShareableListData,
+  testPartialShareableListData,
+} from '../../snowplow/shareableList/testData';
 
 describe('getShareableListEventPayload', () => {
   it('should convert shareable_list_created event request body to Snowplow ShareableList', () => {
@@ -23,7 +26,7 @@ describe('getShareableListEventPayload', () => {
   });
 
   it('should convert shareable_list_updated event request body to Snowplow ShareableList', () => {
-    const shareableListCreatedEvent: ShareableListEventPayloadSnowplow = {
+    const shareableListUpdatedEvent: ShareableListEventPayloadSnowplow = {
       shareable_list: testShareableListData,
       eventType: EventType.SHAREABLE_LIST_UPDATED,
     };
@@ -35,11 +38,11 @@ describe('getShareableListEventPayload', () => {
     };
 
     const payload = getShareableListEventPayload(requestBody);
-    expect(payload).toEqual(shareableListCreatedEvent);
+    expect(payload).toEqual(shareableListUpdatedEvent);
   });
 
   it('should convert shareable_list_deleted event request body to Snowplow ShareableList', () => {
-    const shareableListCreatedEvent: ShareableListEventPayloadSnowplow = {
+    const shareableListDeletedEvent: ShareableListEventPayloadSnowplow = {
       shareable_list: testShareableListData,
       eventType: EventType.SHAREABLE_LIST_DELETED,
     };
@@ -51,11 +54,11 @@ describe('getShareableListEventPayload', () => {
     };
 
     const payload = getShareableListEventPayload(requestBody);
-    expect(payload).toEqual(shareableListCreatedEvent);
+    expect(payload).toEqual(shareableListDeletedEvent);
   });
 
   it('should convert shareable_list_published event request body to Snowplow ShareableList', () => {
-    const shareableListCreatedEvent: ShareableListEventPayloadSnowplow = {
+    const shareableListPublishedEvent: ShareableListEventPayloadSnowplow = {
       shareable_list: testShareableListData,
       eventType: EventType.SHAREABLE_LIST_PUBLISHED,
     };
@@ -67,11 +70,11 @@ describe('getShareableListEventPayload', () => {
     };
 
     const payload = getShareableListEventPayload(requestBody);
-    expect(payload).toEqual(shareableListCreatedEvent);
+    expect(payload).toEqual(shareableListPublishedEvent);
   });
 
   it('should convert shareable_list_unpublished event request body to Snowplow ShareableList', () => {
-    const shareableListCreatedEvent: ShareableListEventPayloadSnowplow = {
+    const shareableListUnpublishedEvent: ShareableListEventPayloadSnowplow = {
       shareable_list: testShareableListData,
       eventType: EventType.SHAREABLE_LIST_UNPUBLISHED,
     };
@@ -83,11 +86,11 @@ describe('getShareableListEventPayload', () => {
     };
 
     const payload = getShareableListEventPayload(requestBody);
-    expect(payload).toEqual(shareableListCreatedEvent);
+    expect(payload).toEqual(shareableListUnpublishedEvent);
   });
 
   it('should convert shareable_list_hidden event request body to Snowplow ShareableList', () => {
-    const shareableListCreatedEvent: ShareableListEventPayloadSnowplow = {
+    const shareableListHiddenEvent: ShareableListEventPayloadSnowplow = {
       shareable_list: testShareableListData,
       eventType: EventType.SHAREABLE_LIST_HIDDEN,
     };
@@ -99,6 +102,22 @@ describe('getShareableListEventPayload', () => {
     };
 
     const payload = getShareableListEventPayload(requestBody);
-    expect(payload).toEqual(shareableListCreatedEvent);
+    expect(payload).toEqual(shareableListHiddenEvent);
+  });
+
+  it('should convert shareable_list_hidden event with missing non-required fields request body to Snowplow ShareableList', () => {
+    const shareableListHiddenEvent: ShareableListEventPayloadSnowplow = {
+      shareable_list: testPartialShareableListData,
+      eventType: EventType.SHAREABLE_LIST_HIDDEN,
+    };
+
+    const requestBody = {
+      'detail-type': 'shareable_list_hidden',
+      source: 'shareable-list-events',
+      detail: { shareableList: testPartialShareableListData },
+    };
+
+    const payload = getShareableListEventPayload(requestBody);
+    expect(payload).toEqual(shareableListHiddenEvent);
   });
 });

--- a/src/eventConsumer/shareableListEvents/shareableListEventConsumer.ts
+++ b/src/eventConsumer/shareableListEvents/shareableListEventConsumer.ts
@@ -1,0 +1,25 @@
+import { ShareableListEventPayloadSnowplow } from '../../snowplow/shareableList/types';
+import { ShareableListEventHandler } from '../../snowplow/shareableList/shareableListEventHandler';
+
+export function shareableListEventConsumer(requestBody: any) {
+  new ShareableListEventHandler().process(
+    getShareableListEventPayload(requestBody)
+  );
+}
+
+/**
+ * converts the event-bridge event format to snowplow payload
+ * for a ShareableList event
+ * @param eventObj event bridge event format
+ */
+export function getShareableListEventPayload(
+  eventObj: any
+): ShareableListEventPayloadSnowplow {
+  const eventPayload = eventObj['detail'];
+  const detailType = eventObj['detail-type'];
+
+  return {
+    shareable_list: eventPayload['shareableList'],
+    eventType: detailType,
+  };
+}

--- a/src/eventConsumer/shareableListItemEvents/shareableListItemEventConsumer.spec.ts
+++ b/src/eventConsumer/shareableListItemEvents/shareableListItemEventConsumer.spec.ts
@@ -1,0 +1,62 @@
+import { getShareableListItemEventPayload } from './shareableListItemEventConsumer';
+import {
+  EventType,
+  ShareableListItemEventPayloadSnowplow,
+} from '../../snowplow/shareableListItem/types';
+import {
+  testShareableListItemData,
+  testPartialShareableListItemData,
+} from '../../snowplow/shareableListItem/testData';
+
+describe('getShareableListItemEventPayload', () => {
+  it('should convert shareable_list_item_created event request body to Snowplow ShareableListItem', () => {
+    const shareableListItemCreatedEvent: ShareableListItemEventPayloadSnowplow =
+      {
+        shareable_list_item: testShareableListItemData,
+        eventType: EventType.SHAREABLE_LIST_ITEM_CREATED,
+      };
+
+    const requestBody = {
+      'detail-type': 'shareable_list_item_created',
+      source: 'shareable-list-item-events',
+      detail: { shareableListItem: testShareableListItemData },
+    };
+
+    const payload = getShareableListItemEventPayload(requestBody);
+    expect(payload).toEqual(shareableListItemCreatedEvent);
+  });
+
+  it('should convert shareable_list_item_deleted event request body to Snowplow ShareableListItem', () => {
+    const shareableListItemDeletedEvent: ShareableListItemEventPayloadSnowplow =
+      {
+        shareable_list_item: testShareableListItemData,
+        eventType: EventType.SHAREABLE_LIST_ITEM_DELETED,
+      };
+
+    const requestBody = {
+      'detail-type': 'shareable_list_item_deleted',
+      source: 'shareable-list-item-events',
+      detail: { shareableListItem: testShareableListItemData },
+    };
+
+    const payload = getShareableListItemEventPayload(requestBody);
+    expect(payload).toEqual(shareableListItemDeletedEvent);
+  });
+
+  it('should convert shareable_list_item_deleted event with missing non-required fields request body to Snowplow ShareableListItem', () => {
+    const shareableListItemDeletedEvent: ShareableListItemEventPayloadSnowplow =
+      {
+        shareable_list_item: testPartialShareableListItemData,
+        eventType: EventType.SHAREABLE_LIST_ITEM_DELETED,
+      };
+
+    const requestBody = {
+      'detail-type': 'shareable_list_item_deleted',
+      source: 'shareable-list-item-events',
+      detail: { shareableListItem: testPartialShareableListItemData },
+    };
+
+    const payload = getShareableListItemEventPayload(requestBody);
+    expect(payload).toEqual(shareableListItemDeletedEvent);
+  });
+});

--- a/src/eventConsumer/shareableListItemEvents/shareableListItemEventConsumer.ts
+++ b/src/eventConsumer/shareableListItemEvents/shareableListItemEventConsumer.ts
@@ -1,0 +1,25 @@
+import { ShareableListItemEventPayloadSnowplow } from '../../snowplow/shareableListItem/types';
+import { ShareableListItemEventHandler } from '../../snowplow/shareableListItem/shareableListItemEventHandler';
+
+export function shareableListItemEventConsumer(requestBody: any) {
+  new ShareableListItemEventHandler().process(
+    getShareableListItemEventPayload(requestBody)
+  );
+}
+
+/**
+ * converts the event-bridge event format to snowplow payload
+ * for a ShareableListItem event
+ * @param eventObj event bridge event format
+ */
+export function getShareableListItemEventPayload(
+  eventObj: any
+): ShareableListItemEventPayloadSnowplow {
+  const eventPayload = eventObj['detail'];
+  const detailType = eventObj['detail-type'];
+
+  return {
+    shareable_list_item: eventPayload['shareableListItem'],
+    eventType: detailType,
+  };
+}

--- a/src/snowplow/collection/collectionEventHandler.integration.ts
+++ b/src/snowplow/collection/collectionEventHandler.integration.ts
@@ -1,32 +1,13 @@
-import fetch from 'node-fetch';
 import { expect } from 'chai';
-import { config } from '../../config';
 import { ObjectUpdate, EventType, collectionEventSchema } from './types';
 import { CollectionEventHandler } from './collectionEventHandler';
 import { testCollectionData } from './testData';
-
-async function snowplowRequest(path: string, post = false): Promise<any> {
-  const response = await fetch(`http://${config.snowplow.endpoint}${path}`, {
-    method: post ? 'POST' : 'GET',
-  });
-  return await response.json();
-}
-
-async function resetSnowplowEvents(): Promise<void> {
-  await snowplowRequest('/micro/reset', true);
-}
-
-async function getAllSnowplowEvents(): Promise<{ [key: string]: any }> {
-  return snowplowRequest('/micro/all');
-}
-
-async function getGoodSnowplowEvents(): Promise<{ [key: string]: any }> {
-  return snowplowRequest('/micro/good');
-}
-
-function parseSnowplowData(data: string): { [key: string]: any } {
-  return JSON.parse(Buffer.from(data, 'base64').toString());
-}
+import {
+  resetSnowplowEvents,
+  getAllSnowplowEvents,
+  getGoodSnowplowEvents,
+  parseSnowplowData,
+} from '../testUtils';
 
 function assertValidSnowplowObjectUpdateEvents(
   events,

--- a/src/snowplow/prospect/prospectEventHandler.integration.ts
+++ b/src/snowplow/prospect/prospectEventHandler.integration.ts
@@ -1,32 +1,13 @@
-import fetch from 'node-fetch';
 import { expect } from 'chai';
-import { config } from '../../config';
 import { ObjectUpdate, EventType, prospectEventSchema } from './types';
 import { ProspectEventHandler } from './prospectEventHandler';
 import { testProspectData } from './testData';
-
-async function snowplowRequest(path: string, post = false): Promise<any> {
-  const response = await fetch(`http://${config.snowplow.endpoint}${path}`, {
-    method: post ? 'POST' : 'GET',
-  });
-  return await response.json();
-}
-
-async function resetSnowplowEvents(): Promise<void> {
-  await snowplowRequest('/micro/reset', true);
-}
-
-async function getAllSnowplowEvents(): Promise<{ [key: string]: any }> {
-  return snowplowRequest('/micro/all');
-}
-
-async function getGoodSnowplowEvents(): Promise<{ [key: string]: any }> {
-  return snowplowRequest('/micro/good');
-}
-
-function parseSnowplowData(data: string): { [key: string]: any } {
-  return JSON.parse(Buffer.from(data, 'base64').toString());
-}
+import {
+  resetSnowplowEvents,
+  getAllSnowplowEvents,
+  getGoodSnowplowEvents,
+  parseSnowplowData,
+} from '../testUtils';
 
 function assertValidSnowplowObjectUpdateEvents(
   events,

--- a/src/snowplow/shareableList/shareableListEventHandler.integration.ts
+++ b/src/snowplow/shareableList/shareableListEventHandler.integration.ts
@@ -1,0 +1,252 @@
+import fetch from 'node-fetch';
+import { expect } from 'chai';
+import { config } from '../../config';
+import { ObjectUpdate, EventType, shareableListEventSchema } from './types';
+import { ShareableListEventHandler } from './shareableListEventHandler';
+import { testShareableListData } from './testData';
+
+async function snowplowRequest(path: string, post = false): Promise<any> {
+  const response = await fetch(`http://${config.snowplow.endpoint}${path}`, {
+    method: post ? 'POST' : 'GET',
+  });
+  return await response.json();
+}
+
+async function resetSnowplowEvents(): Promise<void> {
+  await snowplowRequest('/micro/reset', true);
+}
+
+async function getAllSnowplowEvents(): Promise<{ [key: string]: any }> {
+  return snowplowRequest('/micro/all');
+}
+
+async function getGoodSnowplowEvents(): Promise<{ [key: string]: any }> {
+  return snowplowRequest('/micro/good');
+}
+
+function parseSnowplowData(data: string): { [key: string]: any } {
+  return JSON.parse(Buffer.from(data, 'base64').toString());
+}
+
+function assertValidSnowplowObjectUpdateEvents(
+  events,
+  triggers: ObjectUpdate['data']['trigger'][]
+) {
+  const parsedEvents = events
+    .map(parseSnowplowData)
+    .map((parsedEvent) => parsedEvent.data);
+
+  expect(parsedEvents).to.include.deep.members(
+    triggers.map((trigger) => ({
+      schema: shareableListEventSchema.objectUpdate,
+      data: { trigger: trigger, object: 'shareable_list' },
+    }))
+  );
+}
+
+function assertShareableListSchema(eventContext) {
+  expect(eventContext.data).to.include.deep.members([
+    {
+      schema: shareableListEventSchema.shareable_list,
+      data: {
+        shareable_list_external_id:
+          testShareableListData.shareable_list_external_id,
+        slug: testShareableListData.slug,
+        title: testShareableListData.title,
+        description: testShareableListData.description,
+        status: testShareableListData.status,
+        moderation_status: testShareableListData.moderation_status,
+        moderated_by: testShareableListData.moderated_by,
+        moderation_reason: testShareableListData.moderation_reason,
+        created_at: testShareableListData.created_at,
+        updated_at: testShareableListData.updated_at,
+      },
+    },
+  ]);
+}
+
+const testEventData = {
+  shareable_list: {
+    ...testShareableListData,
+  },
+};
+
+describe('ShareableListEventHandler', () => {
+  beforeEach(async () => {
+    await resetSnowplowEvents();
+  });
+
+  it('should send shareable_list_created event to snowplow', async () => {
+    new ShareableListEventHandler().process({
+      ...testEventData,
+      eventType: EventType.SHAREABLE_LIST_CREATED,
+    });
+
+    // wait a sec * 3
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+
+    // make sure we only have good events
+    const allEvents = await getAllSnowplowEvents();
+    expect(allEvents.total).to.equal(1);
+    expect(allEvents.good).to.equal(1);
+    expect(allEvents.bad).to.equal(0);
+
+    const goodEvents = await getGoodSnowplowEvents();
+
+    const eventContext = parseSnowplowData(
+      goodEvents[0].rawEvent.parameters.cx
+    );
+
+    assertShareableListSchema(eventContext);
+
+    assertValidSnowplowObjectUpdateEvents(
+      goodEvents.map((goodEvent) => goodEvent.rawEvent.parameters.ue_px),
+      [EventType.SHAREABLE_LIST_CREATED]
+    );
+  });
+
+  it('should send shareable_list_updated event to snowplow', async () => {
+    new ShareableListEventHandler().process({
+      ...testEventData,
+      eventType: EventType.SHAREABLE_LIST_UPDATED,
+    });
+
+    // wait a sec * 3
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+
+    // make sure we only have good events
+    const allEvents = await getAllSnowplowEvents();
+    expect(allEvents.total).to.equal(1);
+    expect(allEvents.good).to.equal(1);
+    expect(allEvents.bad).to.equal(0);
+
+    const goodEvents = await getGoodSnowplowEvents();
+
+    const eventContext = parseSnowplowData(
+      goodEvents[0].rawEvent.parameters.cx
+    );
+
+    assertShareableListSchema(eventContext);
+
+    assertValidSnowplowObjectUpdateEvents(
+      goodEvents.map((goodEvent) => goodEvent.rawEvent.parameters.ue_px),
+      [EventType.SHAREABLE_LIST_UPDATED]
+    );
+  });
+
+  it('should send shareable_list_deleted event to snowplow', async () => {
+    new ShareableListEventHandler().process({
+      ...testEventData,
+      eventType: EventType.SHAREABLE_LIST_DELETED,
+    });
+
+    // wait a sec * 3
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+
+    // make sure we only have good events
+    const allEvents = await getAllSnowplowEvents();
+    expect(allEvents.total).to.equal(1);
+    expect(allEvents.good).to.equal(1);
+    expect(allEvents.bad).to.equal(0);
+
+    const goodEvents = await getGoodSnowplowEvents();
+
+    const eventContext = parseSnowplowData(
+      goodEvents[0].rawEvent.parameters.cx
+    );
+
+    assertShareableListSchema(eventContext);
+
+    assertValidSnowplowObjectUpdateEvents(
+      goodEvents.map((goodEvent) => goodEvent.rawEvent.parameters.ue_px),
+      [EventType.SHAREABLE_LIST_DELETED]
+    );
+  });
+
+  it('should send shareable_list_published event to snowplow', async () => {
+    new ShareableListEventHandler().process({
+      ...testEventData,
+      eventType: EventType.SHAREABLE_LIST_PUBLISHED,
+    });
+
+    // wait a sec * 3
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+
+    // make sure we only have good events
+    const allEvents = await getAllSnowplowEvents();
+    expect(allEvents.total).to.equal(1);
+    expect(allEvents.good).to.equal(1);
+    expect(allEvents.bad).to.equal(0);
+
+    const goodEvents = await getGoodSnowplowEvents();
+
+    const eventContext = parseSnowplowData(
+      goodEvents[0].rawEvent.parameters.cx
+    );
+
+    assertShareableListSchema(eventContext);
+
+    assertValidSnowplowObjectUpdateEvents(
+      goodEvents.map((goodEvent) => goodEvent.rawEvent.parameters.ue_px),
+      [EventType.SHAREABLE_LIST_PUBLISHED]
+    );
+  });
+
+  it('should send shareable_list_unpublished event to snowplow', async () => {
+    new ShareableListEventHandler().process({
+      ...testEventData,
+      eventType: EventType.SHAREABLE_LIST_UNPUBLISHED,
+    });
+
+    // wait a sec * 3
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+
+    // make sure we only have good events
+    const allEvents = await getAllSnowplowEvents();
+    expect(allEvents.total).to.equal(1);
+    expect(allEvents.good).to.equal(1);
+    expect(allEvents.bad).to.equal(0);
+
+    const goodEvents = await getGoodSnowplowEvents();
+
+    const eventContext = parseSnowplowData(
+      goodEvents[0].rawEvent.parameters.cx
+    );
+
+    assertShareableListSchema(eventContext);
+
+    assertValidSnowplowObjectUpdateEvents(
+      goodEvents.map((goodEvent) => goodEvent.rawEvent.parameters.ue_px),
+      [EventType.SHAREABLE_LIST_UNPUBLISHED]
+    );
+  });
+
+  it('should send shareable_list_hidden event to snowplow', async () => {
+    new ShareableListEventHandler().process({
+      ...testEventData,
+      eventType: EventType.SHAREABLE_LIST_HIDDEN,
+    });
+
+    // wait a sec * 3
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+
+    // make sure we only have good events
+    const allEvents = await getAllSnowplowEvents();
+    expect(allEvents.total).to.equal(1);
+    expect(allEvents.good).to.equal(1);
+    expect(allEvents.bad).to.equal(0);
+
+    const goodEvents = await getGoodSnowplowEvents();
+
+    const eventContext = parseSnowplowData(
+      goodEvents[0].rawEvent.parameters.cx
+    );
+
+    assertShareableListSchema(eventContext);
+
+    assertValidSnowplowObjectUpdateEvents(
+      goodEvents.map((goodEvent) => goodEvent.rawEvent.parameters.ue_px),
+      [EventType.SHAREABLE_LIST_HIDDEN]
+    );
+  });
+});

--- a/src/snowplow/shareableList/shareableListEventHandler.integration.ts
+++ b/src/snowplow/shareableList/shareableListEventHandler.integration.ts
@@ -1,35 +1,16 @@
-import fetch from 'node-fetch';
 import { expect } from 'chai';
-import { config } from '../../config';
 import { ObjectUpdate, EventType, shareableListEventSchema } from './types';
 import { ShareableListEventHandler } from './shareableListEventHandler';
 import {
   testShareableListData,
   testPartialShareableListData,
 } from './testData';
-
-async function snowplowRequest(path: string, post = false): Promise<any> {
-  const response = await fetch(`http://${config.snowplow.endpoint}${path}`, {
-    method: post ? 'POST' : 'GET',
-  });
-  return await response.json();
-}
-
-async function resetSnowplowEvents(): Promise<void> {
-  await snowplowRequest('/micro/reset', true);
-}
-
-async function getAllSnowplowEvents(): Promise<{ [key: string]: any }> {
-  return snowplowRequest('/micro/all');
-}
-
-async function getGoodSnowplowEvents(): Promise<{ [key: string]: any }> {
-  return snowplowRequest('/micro/good');
-}
-
-function parseSnowplowData(data: string): { [key: string]: any } {
-  return JSON.parse(Buffer.from(data, 'base64').toString());
-}
+import {
+  resetSnowplowEvents,
+  getAllSnowplowEvents,
+  getGoodSnowplowEvents,
+  parseSnowplowData,
+} from '../testUtils';
 
 function assertValidSnowplowObjectUpdateEvents(
   events,

--- a/src/snowplow/shareableList/shareableListEventHandler.ts
+++ b/src/snowplow/shareableList/shareableListEventHandler.ts
@@ -67,13 +67,21 @@ export class ShareableListEventHandler extends EventHandler {
           data.shareable_list.shareable_list_external_id,
         slug: data.shareable_list.slug,
         title: data.shareable_list.title,
-        description: data.shareable_list.description,
+        description: data.shareable_list.description
+          ? data.shareable_list.description
+          : undefined,
         status: data.shareable_list.status,
         moderation_status: data.shareable_list.moderation_status,
-        moderated_by: data.shareable_list.moderated_by,
-        moderation_reason: data.shareable_list.moderation_reason,
+        moderated_by: data.shareable_list.moderated_by
+          ? data.shareable_list.moderated_by
+          : undefined,
+        moderation_reason: data.shareable_list.moderation_reason
+          ? data.shareable_list.moderation_reason
+          : undefined,
         created_at: data.shareable_list.created_at,
-        updated_at: data.shareable_list.updated_at,
+        updated_at: data.shareable_list.updated_at
+          ? data.shareable_list.updated_at
+          : undefined,
       },
     };
     return snowplowEvent;

--- a/src/snowplow/shareableList/shareableListEventHandler.ts
+++ b/src/snowplow/shareableList/shareableListEventHandler.ts
@@ -1,0 +1,81 @@
+import { buildSelfDescribingEvent } from '@snowplow/node-tracker';
+import { SelfDescribingJson } from '@snowplow/tracker-core';
+import {
+  ShareableList,
+  ShareableListEventPayloadSnowplow,
+  ObjectUpdate,
+  shareableListEventSchema,
+} from './types';
+import { config } from '../../config';
+import { EventHandler } from '../EventHandler';
+import { getTracker } from '../tracker';
+
+/**
+ * class to send `shareable-list-event` to snowplow
+ */
+export class ShareableListEventHandler extends EventHandler {
+  constructor() {
+    const tracker = getTracker(config.snowplow.appIds.shareableListsApi);
+    super(tracker);
+    return this;
+  }
+
+  /**
+   * method to create and process event data
+   * @param data
+   */
+  process(data: ShareableListEventPayloadSnowplow): void {
+    const event = buildSelfDescribingEvent({
+      event: ShareableListEventHandler.generateShareableListEvent(data),
+    });
+    const context: SelfDescribingJson[] =
+      ShareableListEventHandler.generateEventContext(data);
+    super.addToTrackerQueue(event, context);
+  }
+
+  /**
+   * Builds the Snowplow object_update event object. Extracts the event trigger type from the received payload.
+   */
+  private static generateShareableListEvent(
+    data: ShareableListEventPayloadSnowplow
+  ): ObjectUpdate {
+    return {
+      schema: shareableListEventSchema.objectUpdate,
+      data: {
+        trigger: data.eventType,
+        object: 'shareable_list',
+      },
+    };
+  }
+
+  private static generateEventContext(
+    data: ShareableListEventPayloadSnowplow
+  ): SelfDescribingJson[] {
+    return [ShareableListEventHandler.generateSnowplowShareableListEvent(data)];
+  }
+
+  /**
+   * Static method to generate an object that maps properties received in the event payload object to the snowplow shareable_list object schema.
+   */
+  private static generateSnowplowShareableListEvent(
+    data: ShareableListEventPayloadSnowplow
+  ): ShareableList {
+    const snowplowEvent = {
+      schema: shareableListEventSchema.shareable_list,
+      data: {
+        shareable_list_external_id:
+          data.shareable_list.shareable_list_external_id,
+        slug: data.shareable_list.slug,
+        title: data.shareable_list.title,
+        description: data.shareable_list.description,
+        status: data.shareable_list.status,
+        moderation_status: data.shareable_list.moderation_status,
+        moderated_by: data.shareable_list.moderated_by,
+        moderation_reason: data.shareable_list.moderation_reason,
+        created_at: data.shareable_list.created_at,
+        updated_at: data.shareable_list.updated_at,
+      },
+    };
+    return snowplowEvent;
+  }
+}

--- a/src/snowplow/shareableList/testData.ts
+++ b/src/snowplow/shareableList/testData.ts
@@ -1,0 +1,14 @@
+import { ShareableList, ListStatus, ModerationStatus } from './types';
+
+export const testShareableListData: ShareableList['data'] = {
+  shareable_list_external_id: 'test-shareable-list-external-id',
+  slug: 'test-shareable-list-slug',
+  title: 'Test Shareable List Title',
+  description: 'Test shareable list description',
+  status: ListStatus.PUBLIC,
+  moderation_status: ModerationStatus.VISIBLE,
+  moderated_by: 'fake-moderator-username',
+  moderation_reason: 'fake-moderator-reason',
+  created_at: 1675978338, // 2023-02-09 16:32:18
+  updated_at: 1675978338,
+};

--- a/src/snowplow/shareableList/testData.ts
+++ b/src/snowplow/shareableList/testData.ts
@@ -12,3 +12,13 @@ export const testShareableListData: ShareableList['data'] = {
   created_at: 1675978338, // 2023-02-09 16:32:18
   updated_at: 1675978338,
 };
+
+// data with missing non-required fields
+export const testPartialShareableListData: ShareableList['data'] = {
+  shareable_list_external_id: 'test-shareable-list-external-id',
+  slug: 'test-shareable-list-slug',
+  title: 'Test Shareable List Title',
+  status: ListStatus.PUBLIC,
+  moderation_status: ModerationStatus.VISIBLE,
+  created_at: 1675978338, // 2023-02-09 16:32:18
+};

--- a/src/snowplow/shareableList/types.ts
+++ b/src/snowplow/shareableList/types.ts
@@ -1,0 +1,53 @@
+import { SelfDescribingJson } from '@snowplow/tracker-core';
+
+export const shareableListEventSchema = {
+  objectUpdate: 'iglu:com.pocket/object_update/jsonschema/1-0-14',
+  shareable_list: 'iglu:com.pocket/shareable_list/jsonschema/1-0-2',
+};
+
+export type ShareableListEventPayloadSnowplow = {
+  shareable_list: ShareableList['data'];
+  eventType: EventType;
+};
+
+export type ObjectUpdate = {
+  schema: string;
+  data: {
+    trigger: EventType;
+    object: 'shareable_list';
+  };
+};
+
+export enum EventType {
+  SHAREABLE_LIST_CREATED = 'shareable_list_created',
+  SHAREABLE_LIST_UPDATED = 'shareable_list_updated',
+  SHAREABLE_LIST_DELETED = 'shareable_list_deleted',
+  SHAREABLE_LIST_PUBLISHED = 'shareable_list_published',
+  SHAREABLE_LIST_UNPUBLISHED = 'shareable_list_unpublished',
+  SHAREABLE_LIST_HIDDEN = 'shareable_list_hidden',
+}
+
+export type ShareableList = Omit<SelfDescribingJson, 'data'> & {
+  data: {
+    shareable_list_external_id: string;
+    slug: string;
+    title: string;
+    description?: string;
+    status: ListStatus;
+    moderation_status: ModerationStatus;
+    moderated_by?: string;
+    moderation_reason?: string;
+    created_at: number; // snowplow schema requires this field in seconds
+    updated_at?: number; // snowplow schema requires this field in seconds
+  };
+};
+
+export enum ListStatus {
+  PRIVATE = 'PRIVATE',
+  PUBLIC = 'PUBLIC',
+}
+
+export enum ModerationStatus {
+  VISIBLE = 'VISIBLE',
+  HIDDEN = 'HIDDEN',
+}

--- a/src/snowplow/shareableListItem/shareableListItemEventHandler.integration.ts
+++ b/src/snowplow/shareableListItem/shareableListItemEventHandler.integration.ts
@@ -1,35 +1,16 @@
-import fetch from 'node-fetch';
 import { expect } from 'chai';
-import { config } from '../../config';
 import { ObjectUpdate, EventType, shareableListItemEventSchema } from './types';
 import { ShareableListItemEventHandler } from './shareableListItemEventHandler';
 import {
   testShareableListItemData,
   testPartialShareableListItemData,
 } from './testData';
-
-async function snowplowRequest(path: string, post = false): Promise<any> {
-  const response = await fetch(`http://${config.snowplow.endpoint}${path}`, {
-    method: post ? 'POST' : 'GET',
-  });
-  return await response.json();
-}
-
-async function resetSnowplowEvents(): Promise<void> {
-  await snowplowRequest('/micro/reset', true);
-}
-
-async function getAllSnowplowEvents(): Promise<{ [key: string]: any }> {
-  return snowplowRequest('/micro/all');
-}
-
-async function getGoodSnowplowEvents(): Promise<{ [key: string]: any }> {
-  return snowplowRequest('/micro/good');
-}
-
-function parseSnowplowData(data: string): { [key: string]: any } {
-  return JSON.parse(Buffer.from(data, 'base64').toString());
-}
+import {
+  resetSnowplowEvents,
+  getAllSnowplowEvents,
+  getGoodSnowplowEvents,
+  parseSnowplowData,
+} from '../testUtils';
 
 function assertValidSnowplowObjectUpdateEvents(
   events,

--- a/src/snowplow/shareableListItem/shareableListItemEventHandler.integration.ts
+++ b/src/snowplow/shareableListItem/shareableListItemEventHandler.integration.ts
@@ -1,0 +1,193 @@
+import fetch from 'node-fetch';
+import { expect } from 'chai';
+import { config } from '../../config';
+import { ObjectUpdate, EventType, shareableListItemEventSchema } from './types';
+import { ShareableListItemEventHandler } from './shareableListItemEventHandler';
+import {
+  testShareableListItemData,
+  testPartialShareableListItemData,
+} from './testData';
+
+async function snowplowRequest(path: string, post = false): Promise<any> {
+  const response = await fetch(`http://${config.snowplow.endpoint}${path}`, {
+    method: post ? 'POST' : 'GET',
+  });
+  return await response.json();
+}
+
+async function resetSnowplowEvents(): Promise<void> {
+  await snowplowRequest('/micro/reset', true);
+}
+
+async function getAllSnowplowEvents(): Promise<{ [key: string]: any }> {
+  return snowplowRequest('/micro/all');
+}
+
+async function getGoodSnowplowEvents(): Promise<{ [key: string]: any }> {
+  return snowplowRequest('/micro/good');
+}
+
+function parseSnowplowData(data: string): { [key: string]: any } {
+  return JSON.parse(Buffer.from(data, 'base64').toString());
+}
+
+function assertValidSnowplowObjectUpdateEvents(
+  events,
+  triggers: ObjectUpdate['data']['trigger'][]
+) {
+  const parsedEvents = events
+    .map(parseSnowplowData)
+    .map((parsedEvent) => parsedEvent.data);
+
+  expect(parsedEvents).to.include.deep.members(
+    triggers.map((trigger) => ({
+      schema: shareableListItemEventSchema.objectUpdate,
+      data: { trigger: trigger, object: 'shareable_list_item' },
+    }))
+  );
+}
+
+function assertShareableListItemSchema(eventContext) {
+  expect(eventContext.data).to.include.deep.members([
+    {
+      schema: shareableListItemEventSchema.shareable_list_item,
+      data: {
+        shareable_list_item_external_id:
+          testShareableListItemData.shareable_list_item_external_id,
+        shareable_list_external_id:
+          testShareableListItemData.shareable_list_external_id,
+        given_url: testShareableListItemData.given_url,
+        title: testShareableListItemData.title,
+        excerpt: testShareableListItemData.excerpt,
+        image_url: testShareableListItemData.image_url,
+        authors: testShareableListItemData.authors,
+        publisher: testShareableListItemData.publisher,
+        sort_order: testShareableListItemData.sort_order,
+        created_at: testShareableListItemData.created_at,
+        updated_at: testShareableListItemData.updated_at,
+      },
+    },
+  ]);
+}
+
+function assertPartialShareableListItemSchema(eventContext) {
+  expect(eventContext.data).to.include.deep.members([
+    {
+      schema: shareableListItemEventSchema.shareable_list_item,
+      data: {
+        shareable_list_item_external_id:
+          testPartialShareableListItemData.shareable_list_item_external_id,
+        shareable_list_external_id:
+          testPartialShareableListItemData.shareable_list_external_id,
+        given_url: testPartialShareableListItemData.given_url,
+        sort_order: testPartialShareableListItemData.sort_order,
+        created_at: testPartialShareableListItemData.created_at,
+      },
+    },
+  ]);
+}
+
+const testEventData = {
+  shareable_list_item: {
+    ...testShareableListItemData,
+  },
+};
+
+const testPartialEventData = {
+  shareable_list_item: {
+    ...testPartialShareableListItemData,
+  },
+};
+
+describe('ShareableListItemEventHandler', () => {
+  beforeEach(async () => {
+    await resetSnowplowEvents();
+  });
+
+  it('should send shareable_list_item_created event to snowplow', async () => {
+    new ShareableListItemEventHandler().process({
+      ...testEventData,
+      eventType: EventType.SHAREABLE_LIST_ITEM_CREATED,
+    });
+
+    // wait a sec * 3
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+
+    // make sure we only have good events
+    const allEvents = await getAllSnowplowEvents();
+    expect(allEvents.total).to.equal(1);
+    expect(allEvents.good).to.equal(1);
+    expect(allEvents.bad).to.equal(0);
+
+    const goodEvents = await getGoodSnowplowEvents();
+
+    const eventContext = parseSnowplowData(
+      goodEvents[0].rawEvent.parameters.cx
+    );
+
+    assertShareableListItemSchema(eventContext);
+
+    assertValidSnowplowObjectUpdateEvents(
+      goodEvents.map((goodEvent) => goodEvent.rawEvent.parameters.ue_px),
+      [EventType.SHAREABLE_LIST_ITEM_CREATED]
+    );
+  });
+
+  it('should send shareable_list_item_deleted event to snowplow', async () => {
+    new ShareableListItemEventHandler().process({
+      ...testEventData,
+      eventType: EventType.SHAREABLE_LIST_ITEM_DELETED,
+    });
+
+    // wait a sec * 3
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+
+    // make sure we only have good events
+    const allEvents = await getAllSnowplowEvents();
+    expect(allEvents.total).to.equal(1);
+    expect(allEvents.good).to.equal(1);
+    expect(allEvents.bad).to.equal(0);
+
+    const goodEvents = await getGoodSnowplowEvents();
+
+    const eventContext = parseSnowplowData(
+      goodEvents[0].rawEvent.parameters.cx
+    );
+
+    assertShareableListItemSchema(eventContext);
+
+    assertValidSnowplowObjectUpdateEvents(
+      goodEvents.map((goodEvent) => goodEvent.rawEvent.parameters.ue_px),
+      [EventType.SHAREABLE_LIST_ITEM_DELETED]
+    );
+  });
+
+  it('should send shareable_list_item_deleted event with missing non-required fields to snowplow', async () => {
+    new ShareableListItemEventHandler().process({
+      ...testPartialEventData,
+      eventType: EventType.SHAREABLE_LIST_ITEM_DELETED,
+    });
+
+    // wait a sec * 3
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+
+    // make sure we only have good events
+    const allEvents = await getAllSnowplowEvents();
+    expect(allEvents.total).to.equal(1);
+    expect(allEvents.good).to.equal(1);
+    expect(allEvents.bad).to.equal(0);
+
+    const goodEvents = await getGoodSnowplowEvents();
+
+    const eventContext = parseSnowplowData(
+      goodEvents[0].rawEvent.parameters.cx
+    );
+
+    assertPartialShareableListItemSchema(eventContext);
+
+    assertValidSnowplowObjectUpdateEvents(
+      goodEvents.map((goodEvent) => goodEvent.rawEvent.parameters.ue_px),
+      [EventType.SHAREABLE_LIST_ITEM_DELETED]
+    );
+  });
+});

--- a/src/snowplow/shareableListItem/shareableListItemEventHandler.ts
+++ b/src/snowplow/shareableListItem/shareableListItemEventHandler.ts
@@ -1,0 +1,99 @@
+import { buildSelfDescribingEvent } from '@snowplow/node-tracker';
+import { SelfDescribingJson } from '@snowplow/tracker-core';
+import {
+  ShareableListItem,
+  ShareableListItemEventPayloadSnowplow,
+  ObjectUpdate,
+  shareableListItemEventSchema,
+} from './types';
+import { config } from '../../config';
+import { EventHandler } from '../EventHandler';
+import { getTracker } from '../tracker';
+
+/**
+ * class to send `shareable-list-item-event` to snowplow
+ */
+export class ShareableListItemEventHandler extends EventHandler {
+  constructor() {
+    const tracker = getTracker(config.snowplow.appIds.shareableListsApi);
+    super(tracker);
+    return this;
+  }
+
+  /**
+   * method to create and process event data
+   * @param data
+   */
+  process(data: ShareableListItemEventPayloadSnowplow): void {
+    const event = buildSelfDescribingEvent({
+      event: ShareableListItemEventHandler.generateShareableListItemEvent(data),
+    });
+    const context: SelfDescribingJson[] =
+      ShareableListItemEventHandler.generateEventContext(data);
+    super.addToTrackerQueue(event, context);
+  }
+
+  /**
+   * Builds the Snowplow object_update event object. Extracts the event trigger type from the received payload.
+   */
+  private static generateShareableListItemEvent(
+    data: ShareableListItemEventPayloadSnowplow
+  ): ObjectUpdate {
+    return {
+      schema: shareableListItemEventSchema.objectUpdate,
+      data: {
+        trigger: data.eventType,
+        object: 'shareable_list_item',
+      },
+    };
+  }
+
+  private static generateEventContext(
+    data: ShareableListItemEventPayloadSnowplow
+  ): SelfDescribingJson[] {
+    return [
+      ShareableListItemEventHandler.generateSnowplowShareableListItemEvent(
+        data
+      ),
+    ];
+  }
+
+  /**
+   * Static method to generate an object that maps properties received in the event payload object to the snowplow shareable_list_item object schema.
+   */
+  private static generateSnowplowShareableListItemEvent(
+    data: ShareableListItemEventPayloadSnowplow
+  ): ShareableListItem {
+    const snowplowEvent = {
+      schema: shareableListItemEventSchema.shareable_list_item,
+      data: {
+        shareable_list_item_external_id:
+          data.shareable_list_item.shareable_list_item_external_id,
+        shareable_list_external_id:
+          data.shareable_list_item.shareable_list_external_id,
+        given_url: data.shareable_list_item.given_url,
+        title: data.shareable_list_item.title
+          ? data.shareable_list_item.title
+          : undefined,
+        excerpt: data.shareable_list_item.excerpt
+          ? data.shareable_list_item.excerpt
+          : undefined,
+        image_url: data.shareable_list_item.image_url
+          ? data.shareable_list_item.image_url
+          : undefined,
+        authors: data.shareable_list_item.authors
+          ? data.shareable_list_item.authors
+          : undefined,
+        publisher: data.shareable_list_item.publisher
+          ? data.shareable_list_item.publisher
+          : undefined,
+        sort_order: data.shareable_list_item.sort_order,
+        created_at: data.shareable_list_item.created_at,
+        updated_at: data.shareable_list_item.updated_at
+          ? data.shareable_list_item.updated_at
+          : undefined,
+      },
+    };
+    return snowplowEvent;
+  }
+}

--- a/src/snowplow/shareableListItem/testData.ts
+++ b/src/snowplow/shareableListItem/testData.ts
@@ -1,0 +1,24 @@
+import { ShareableListItem } from './types';
+
+export const testShareableListItemData: ShareableListItem['data'] = {
+  shareable_list_item_external_id: 'test-shareable-list-item-external-id',
+  shareable_list_external_id: 'test-shareable-list-external-id',
+  given_url: 'https://test-shareable-list-item-given-url.com',
+  title: 'Test Shareable List Item Title',
+  excerpt: 'Test shareable list item excerpt',
+  image_url: 'https://test-shareable-list-item-image-url.com',
+  authors: ['Author1', 'Author2'],
+  publisher: 'Fake Publisher',
+  sort_order: 1,
+  created_at: 1675978338, // 2023-02-09 16:32:18
+  updated_at: 1675978338,
+};
+
+// data with missing non-required fields
+export const testPartialShareableListItemData: ShareableListItem['data'] = {
+  shareable_list_item_external_id: 'test-shareable-list-item-external-id',
+  shareable_list_external_id: 'test-shareable-list-external-id',
+  given_url: 'https://test-shareable-list-item-given-url.com',
+  sort_order: 1,
+  created_at: 1675978338, // 2023-02-09 16:32:18
+};

--- a/src/snowplow/shareableListItem/types.ts
+++ b/src/snowplow/shareableListItem/types.ts
@@ -1,0 +1,40 @@
+import { SelfDescribingJson } from '@snowplow/tracker-core';
+
+export const shareableListItemEventSchema = {
+  objectUpdate: 'iglu:com.pocket/object_update/jsonschema/1-0-14',
+  shareable_list_item: 'iglu:com.pocket/shareable_list_item/jsonschema/1-0-2',
+};
+
+export type ShareableListItemEventPayloadSnowplow = {
+  shareable_list_item: ShareableListItem['data'];
+  eventType: EventType;
+};
+
+export type ObjectUpdate = {
+  schema: string;
+  data: {
+    trigger: EventType;
+    object: 'shareable_list_item';
+  };
+};
+
+export enum EventType {
+  SHAREABLE_LIST_ITEM_CREATED = 'shareable_list_item_created',
+  SHAREABLE_LIST_ITEM_DELETED = 'shareable_list_item_deleted',
+}
+
+export type ShareableListItem = Omit<SelfDescribingJson, 'data'> & {
+  data: {
+    shareable_list_item_external_id: string;
+    shareable_list_external_id: string;
+    given_url: string;
+    title?: string;
+    excerpt?: string;
+    image_url?: string;
+    authors?: string[];
+    publisher?: string;
+    sort_order: number;
+    created_at: number; // snowplow schema requires this field in seconds
+    updated_at?: number; // snowplow schema requires this field in seconds
+  };
+};

--- a/src/snowplow/testUtils.ts
+++ b/src/snowplow/testUtils.ts
@@ -1,0 +1,25 @@
+import fetch from 'node-fetch';
+import { config } from '../config';
+
+async function snowplowRequest(path: string, post = false): Promise<any> {
+  const response = await fetch(`http://${config.snowplow.endpoint}${path}`, {
+    method: post ? 'POST' : 'GET',
+  });
+  return await response.json();
+}
+
+export async function resetSnowplowEvents(): Promise<void> {
+  await snowplowRequest('/micro/reset', true);
+}
+
+export async function getAllSnowplowEvents(): Promise<{ [key: string]: any }> {
+  return snowplowRequest('/micro/all');
+}
+
+export async function getGoodSnowplowEvents(): Promise<{ [key: string]: any }> {
+  return snowplowRequest('/micro/good');
+}
+
+export function parseSnowplowData(data: string): { [key: string]: any } {
+  return JSON.parse(Buffer.from(data, 'base64').toString());
+}

--- a/src/snowplow/user/userEventHandler.integration.ts
+++ b/src/snowplow/user/userEventHandler.integration.ts
@@ -1,31 +1,12 @@
-import fetch from 'node-fetch';
 import { expect } from 'chai';
-import { config } from '../../config';
 import { ObjectUpdate, EventType, userEventsSchema } from './types';
 import { UserEventHandler } from './userEventHandler';
-
-async function snowplowRequest(path: string, post = false): Promise<any> {
-  const response = await fetch(`http://${config.snowplow.endpoint}${path}`, {
-    method: post ? 'POST' : 'GET',
-  });
-  return await response.json();
-}
-
-async function resetSnowplowEvents(): Promise<void> {
-  await snowplowRequest('/micro/reset', true);
-}
-
-async function getAllSnowplowEvents(): Promise<{ [key: string]: any }> {
-  return snowplowRequest('/micro/all');
-}
-
-async function getGoodSnowplowEvents(): Promise<{ [key: string]: any }> {
-  return snowplowRequest('/micro/good');
-}
-
-function parseSnowplowData(data: string): { [key: string]: any } {
-  return JSON.parse(Buffer.from(data, 'base64').toString());
-}
+import {
+  resetSnowplowEvents,
+  getAllSnowplowEvents,
+  getGoodSnowplowEvents,
+  parseSnowplowData,
+} from '../testUtils';
 
 function assertValidSnowplowObjectUpdateEvents(
   events,


### PR DESCRIPTION
## Goal

Consuming SQS messages for `shareable-lists-api` and publishing them to Snowplow. This branch has been already deployed to DEV and ECS logs can be viewed [here](https://us-east-1.console.aws.amazon.com/ecs/v2/clusters/SharedSnowplowConsumer-Dev/services/SharedSnowplowConsumer-Dev/logs?region=us-east-1).

* Created `shareableListEventHandler` and integration tests.
* Created `shareableListEventConsumter` and unit tests.
* Created `shareableListItemEventHandler` and integration tests.
* Created `shareableListItemEventConsumer` and unit tests.
* Minor cleanup in integration tests

JIRA ticket:
* [https://getpocket.atlassian.net/browse/OSL-210](https://getpocket.atlassian.net/browse/OSL-210)
