### PR TITLE
OSL-322: add moderation_details to ShareableList Snowplow type

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
           NODE_ENV: test
           AWS_XRAY_LOG_LEVEL: silent
           AWS_XRAY_CONTEXT_MISSING: LOG_ERROR
-      - image: pocket/snowplow-micro:latest
+      - image: pocket/snowplow-micro:prod
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
           NODE_ENV: test
           AWS_XRAY_LOG_LEVEL: silent
           AWS_XRAY_CONTEXT_MISSING: LOG_ERROR
-      - image: pocket/snowplow-micro:prod
+      - image: pocket/snowplow-micro:latest
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Architecture diagram: https://miro.com/app/board/uXjVO5oHq_U=/
 ```bash
 nvm use
 npm ci
-npm start:dev
+npm run start:dev
 ```
 
 ## To run test for ecs

--- a/src/snowplow/shareableList/shareableListEventHandler.integration.ts
+++ b/src/snowplow/shareableList/shareableListEventHandler.integration.ts
@@ -42,6 +42,7 @@ function assertShareableListSchema(eventContext) {
         moderation_status: testShareableListData.moderation_status,
         moderated_by: testShareableListData.moderated_by,
         moderation_reason: testShareableListData.moderation_reason,
+        moderation_details: testShareableListData.moderation_details,
         created_at: testShareableListData.created_at,
         updated_at: testShareableListData.updated_at,
       },

--- a/src/snowplow/shareableList/shareableListEventHandler.ts
+++ b/src/snowplow/shareableList/shareableListEventHandler.ts
@@ -78,6 +78,9 @@ export class ShareableListEventHandler extends EventHandler {
         moderation_reason: data.shareable_list.moderation_reason
           ? data.shareable_list.moderation_reason
           : undefined,
+        moderation_details: data.shareable_list.moderation_details
+          ? data.shareable_list.moderation_details
+          : undefined,
         created_at: data.shareable_list.created_at,
         updated_at: data.shareable_list.updated_at
           ? data.shareable_list.updated_at

--- a/src/snowplow/shareableList/testData.ts
+++ b/src/snowplow/shareableList/testData.ts
@@ -8,7 +8,8 @@ export const testShareableListData: ShareableList['data'] = {
   status: ListStatus.PUBLIC,
   moderation_status: ModerationStatus.VISIBLE,
   moderated_by: 'fake-moderator-username',
-  moderation_reason: 'fake-moderator-reason',
+  moderation_reason: 'SPAM',
+  moderation_details: 'more details here',
   created_at: 1675978338, // 2023-02-09 16:32:18
   updated_at: 1675978338,
 };

--- a/src/snowplow/shareableList/types.ts
+++ b/src/snowplow/shareableList/types.ts
@@ -2,7 +2,7 @@ import { SelfDescribingJson } from '@snowplow/tracker-core';
 
 export const shareableListEventSchema = {
   objectUpdate: 'iglu:com.pocket/object_update/jsonschema/1-0-14',
-  shareable_list: 'iglu:com.pocket/shareable_list/jsonschema/1-0-2',
+  shareable_list: 'iglu:com.pocket/shareable_list/jsonschema/1-0-3',
 };
 
 export type ShareableListEventPayloadSnowplow = {
@@ -37,6 +37,7 @@ export type ShareableList = Omit<SelfDescribingJson, 'data'> & {
     moderation_status: ModerationStatus;
     moderated_by?: string;
     moderation_reason?: string;
+    moderation_details?: string;
     created_at: number; // snowplow schema requires this field in seconds
     updated_at?: number; // snowplow schema requires this field in seconds
   };


### PR DESCRIPTION
## Goal

Adding `moderation_details` to `ShareableList` Snowplow type. Updating tests.

## JIRA ticket:
* [https://getpocket.atlassian.net/browse/OSL-322](https://getpocket.atlassian.net/browse/OSL-322)
