### PR TITLE
OSL-339: Making slug field optional on shareable_list snowplow entity

### DIFF
--- a/src/snowplow/shareableList/shareableListEventHandler.integration.ts
+++ b/src/snowplow/shareableList/shareableListEventHandler.integration.ts
@@ -57,7 +57,6 @@ function assertPartialShareableListSchema(eventContext) {
       data: {
         shareable_list_external_id:
           testPartialShareableListData.shareable_list_external_id,
-        slug: testPartialShareableListData.slug,
         title: testPartialShareableListData.title,
         status: testPartialShareableListData.status,
         moderation_status: testPartialShareableListData.moderation_status,

--- a/src/snowplow/shareableList/testData.ts
+++ b/src/snowplow/shareableList/testData.ts
@@ -17,7 +17,6 @@ export const testShareableListData: ShareableList['data'] = {
 // data with missing non-required fields
 export const testPartialShareableListData: ShareableList['data'] = {
   shareable_list_external_id: 'test-shareable-list-external-id',
-  slug: 'test-shareable-list-slug',
   title: 'Test Shareable List Title',
   status: ListStatus.PUBLIC,
   moderation_status: ModerationStatus.VISIBLE,

--- a/src/snowplow/shareableList/types.ts
+++ b/src/snowplow/shareableList/types.ts
@@ -2,7 +2,7 @@ import { SelfDescribingJson } from '@snowplow/tracker-core';
 
 export const shareableListEventSchema = {
   objectUpdate: 'iglu:com.pocket/object_update/jsonschema/1-0-14',
-  shareable_list: 'iglu:com.pocket/shareable_list/jsonschema/1-0-3',
+  shareable_list: 'iglu:com.pocket/shareable_list/jsonschema/1-0-4',
 };
 
 export type ShareableListEventPayloadSnowplow = {
@@ -30,7 +30,7 @@ export enum EventType {
 export type ShareableList = Omit<SelfDescribingJson, 'data'> & {
   data: {
     shareable_list_external_id: string;
-    slug: string;
+    slug?: string;
     title: string;
     description?: string;
     status: ListStatus;


### PR DESCRIPTION
## Goal
Analytics updated slug field to be optional on shareable_list entity. Updating slug field to be optional on Snowplow ShareableList type.

## JIRA ticket:
* [https://getpocket.atlassian.net/browse/OSL-339](https://getpocket.atlassian.net/browse/OSL-339)