### PR TITLE
OSL-389: Adding userId to shareable_list snowplow type

### DIFF
--- a/src/snowplow/shareableList/shareableListEventHandler.integration.ts
+++ b/src/snowplow/shareableList/shareableListEventHandler.integration.ts
@@ -35,6 +35,7 @@ function assertShareableListSchema(eventContext) {
       data: {
         shareable_list_external_id:
           testShareableListData.shareable_list_external_id,
+        user_id: testShareableListData.user_id,
         slug: testShareableListData.slug,
         title: testShareableListData.title,
         description: testShareableListData.description,
@@ -57,6 +58,7 @@ function assertPartialShareableListSchema(eventContext) {
       data: {
         shareable_list_external_id:
           testPartialShareableListData.shareable_list_external_id,
+        user_id: testPartialShareableListData.user_id,
         title: testPartialShareableListData.title,
         status: testPartialShareableListData.status,
         moderation_status: testPartialShareableListData.moderation_status,

--- a/src/snowplow/shareableList/shareableListEventHandler.ts
+++ b/src/snowplow/shareableList/shareableListEventHandler.ts
@@ -65,6 +65,9 @@ export class ShareableListEventHandler extends EventHandler {
       data: {
         shareable_list_external_id:
           data.shareable_list.shareable_list_external_id,
+        user_id: data.shareable_list.user_id
+          ? data.shareable_list.user_id
+          : undefined,
         slug: data.shareable_list.slug,
         title: data.shareable_list.title,
         description: data.shareable_list.description

--- a/src/snowplow/shareableList/testData.ts
+++ b/src/snowplow/shareableList/testData.ts
@@ -2,6 +2,7 @@ import { ShareableList, ListStatus, ModerationStatus } from './types';
 
 export const testShareableListData: ShareableList['data'] = {
   shareable_list_external_id: 'test-shareable-list-external-id',
+  user_id: 12345,
   slug: 'test-shareable-list-slug',
   title: 'Test Shareable List Title',
   description: 'Test shareable list description',
@@ -17,6 +18,7 @@ export const testShareableListData: ShareableList['data'] = {
 // data with missing non-required fields
 export const testPartialShareableListData: ShareableList['data'] = {
   shareable_list_external_id: 'test-shareable-list-external-id',
+  user_id: 12345,
   title: 'Test Shareable List Title',
   status: ListStatus.PUBLIC,
   moderation_status: ModerationStatus.VISIBLE,

--- a/src/snowplow/shareableList/types.ts
+++ b/src/snowplow/shareableList/types.ts
@@ -2,7 +2,7 @@ import { SelfDescribingJson } from '@snowplow/tracker-core';
 
 export const shareableListEventSchema = {
   objectUpdate: 'iglu:com.pocket/object_update/jsonschema/1-0-14',
-  shareable_list: 'iglu:com.pocket/shareable_list/jsonschema/1-0-4',
+  shareable_list: 'iglu:com.pocket/shareable_list/jsonschema/1-0-5',
 };
 
 export type ShareableListEventPayloadSnowplow = {
@@ -30,6 +30,7 @@ export enum EventType {
 export type ShareableList = Omit<SelfDescribingJson, 'data'> & {
   data: {
     shareable_list_external_id: string;
+    user_id: bigint | number;
     slug?: string;
     title: string;
     description?: string;


### PR DESCRIPTION
## Goal
Sending userId as part of the ShareableList entity to Snowplow. As per [this request](https://pocket.slack.com/archives/CR6T8BNCT/p1680652916308989).

## JIRA ticket:
* [https://getpocket.atlassian.net/browse/OSL-389](https://getpocket.atlassian.net/browse/OSL-389)

