### PR TITLE
OSL-397-OSL-473: sending new fields to snowplow for shareable-lists-api

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
   test_integrations:
     parameters:
       snowplow_image:
-        default: "pocket/snowplow-micro:prod"
+        default: 'pocket/snowplow-micro:prod'
         type: string
     description: Run integration tests against prod snowplow image
     docker:

--- a/src/eventConsumer/index.ts
+++ b/src/eventConsumer/index.ts
@@ -20,7 +20,9 @@ export enum EventType {
   SHAREABLE_LIST_PUBLISHED = 'shareable_list_published',
   SHAREABLE_LIST_UNPUBLISHED = 'shareable_list_unpublished',
   SHAREABLE_LIST_HIDDEN = 'shareable_list_hidden',
+  SHAREABLE_LIST_UNHIDDEN = 'shareable_list_unhidden',
   SHAREABLE_LIST_ITEM_CREATED = 'shareable_list_item_created',
+  SHAREABLE_LIST_ITEM_UPDATED = 'shareable_list_item_updated',
   SHAREABLE_LIST_ITEM_DELETED = 'shareable_list_item_deleted',
 }
 
@@ -40,6 +42,8 @@ export const eventConsumer: {
   [EventType.SHAREABLE_LIST_PUBLISHED]: shareableListEventConsumer,
   [EventType.SHAREABLE_LIST_UNPUBLISHED]: shareableListEventConsumer,
   [EventType.SHAREABLE_LIST_HIDDEN]: shareableListEventConsumer,
+  [EventType.SHAREABLE_LIST_UNHIDDEN]: shareableListEventConsumer,
   [EventType.SHAREABLE_LIST_ITEM_CREATED]: shareableListItemEventConsumer,
+  [EventType.SHAREABLE_LIST_ITEM_UPDATED]: shareableListItemEventConsumer,
   [EventType.SHAREABLE_LIST_ITEM_DELETED]: shareableListItemEventConsumer,
 };

--- a/src/eventConsumer/shareableListEvents/shareableListEventConsumer.spec.ts
+++ b/src/eventConsumer/shareableListEvents/shareableListEventConsumer.spec.ts
@@ -105,6 +105,22 @@ describe('getShareableListEventPayload', () => {
     expect(payload).toEqual(shareableListHiddenEvent);
   });
 
+  it('should convert shareable_list_unhidden event request body to Snowplow ShareableList', () => {
+    const shareableListHiddenEvent: ShareableListEventPayloadSnowplow = {
+      shareable_list: testShareableListData,
+      eventType: EventType.SHAREABLE_LIST_UNHIDDEN,
+    };
+
+    const requestBody = {
+      'detail-type': 'shareable_list_unhidden',
+      source: 'shareable-list-events',
+      detail: { shareableList: testShareableListData },
+    };
+
+    const payload = getShareableListEventPayload(requestBody);
+    expect(payload).toEqual(shareableListHiddenEvent);
+  });
+
   it('should convert shareable_list_hidden event with missing non-required fields request body to Snowplow ShareableList', () => {
     const shareableListHiddenEvent: ShareableListEventPayloadSnowplow = {
       shareable_list: testPartialShareableListData,

--- a/src/eventConsumer/shareableListItemEvents/shareableListItemEventConsumer.spec.ts
+++ b/src/eventConsumer/shareableListItemEvents/shareableListItemEventConsumer.spec.ts
@@ -26,6 +26,23 @@ describe('getShareableListItemEventPayload', () => {
     expect(payload).toEqual(shareableListItemCreatedEvent);
   });
 
+  it('should convert shareable_list_item_updated event request body to Snowplow ShareableListItem', () => {
+    const shareableListItemCreatedEvent: ShareableListItemEventPayloadSnowplow =
+      {
+        shareable_list_item: testShareableListItemData,
+        eventType: EventType.SHAREABLE_LIST_ITEM_UPDATED,
+      };
+
+    const requestBody = {
+      'detail-type': 'shareable_list_item_updated',
+      source: 'shareable-list-item-events',
+      detail: { shareableListItem: testShareableListItemData },
+    };
+
+    const payload = getShareableListItemEventPayload(requestBody);
+    expect(payload).toEqual(shareableListItemCreatedEvent);
+  });
+
   it('should convert shareable_list_item_deleted event request body to Snowplow ShareableListItem', () => {
     const shareableListItemDeletedEvent: ShareableListItemEventPayloadSnowplow =
       {

--- a/src/snowplow/shareableList/shareableListEventHandler.integration.ts
+++ b/src/snowplow/shareableList/shareableListEventHandler.integration.ts
@@ -40,10 +40,13 @@ function assertShareableListSchema(eventContext) {
         title: testShareableListData.title,
         description: testShareableListData.description,
         status: testShareableListData.status,
+        list_item_note_visibility:
+          testShareableListData.list_item_note_visibility,
         moderation_status: testShareableListData.moderation_status,
         moderated_by: testShareableListData.moderated_by,
         moderation_reason: testShareableListData.moderation_reason,
         moderation_details: testShareableListData.moderation_details,
+        restoration_reason: testShareableListData.restoration_reason,
         created_at: testShareableListData.created_at,
         updated_at: testShareableListData.updated_at,
       },
@@ -61,6 +64,8 @@ function assertPartialShareableListSchema(eventContext) {
         user_id: testPartialShareableListData.user_id,
         title: testPartialShareableListData.title,
         status: testPartialShareableListData.status,
+        list_item_note_visibility:
+          testPartialShareableListData.list_item_note_visibility,
         moderation_status: testPartialShareableListData.moderation_status,
         created_at: testPartialShareableListData.created_at,
       },
@@ -256,6 +261,35 @@ describe('ShareableListEventHandler', () => {
     assertValidSnowplowObjectUpdateEvents(
       goodEvents.map((goodEvent) => goodEvent.rawEvent.parameters.ue_px),
       [EventType.SHAREABLE_LIST_HIDDEN]
+    );
+  });
+
+  it('should send shareable_list_unhidden event to snowplow', async () => {
+    new ShareableListEventHandler().process({
+      ...testEventData,
+      eventType: EventType.SHAREABLE_LIST_UNHIDDEN,
+    });
+
+    // wait a sec * 3
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+
+    // make sure we only have good events
+    const allEvents = await getAllSnowplowEvents();
+    expect(allEvents.total).to.equal(1);
+    expect(allEvents.good).to.equal(1);
+    expect(allEvents.bad).to.equal(0);
+
+    const goodEvents = await getGoodSnowplowEvents();
+
+    const eventContext = parseSnowplowData(
+      goodEvents[0].rawEvent.parameters.cx
+    );
+
+    assertShareableListSchema(eventContext);
+
+    assertValidSnowplowObjectUpdateEvents(
+      goodEvents.map((goodEvent) => goodEvent.rawEvent.parameters.ue_px),
+      [EventType.SHAREABLE_LIST_UNHIDDEN]
     );
   });
 

--- a/src/snowplow/shareableList/shareableListEventHandler.ts
+++ b/src/snowplow/shareableList/shareableListEventHandler.ts
@@ -74,6 +74,8 @@ export class ShareableListEventHandler extends EventHandler {
           ? data.shareable_list.description
           : undefined,
         status: data.shareable_list.status,
+        list_item_note_visibility:
+          data.shareable_list.list_item_note_visibility,
         moderation_status: data.shareable_list.moderation_status,
         moderated_by: data.shareable_list.moderated_by
           ? data.shareable_list.moderated_by
@@ -83,6 +85,9 @@ export class ShareableListEventHandler extends EventHandler {
           : undefined,
         moderation_details: data.shareable_list.moderation_details
           ? data.shareable_list.moderation_details
+          : undefined,
+        restoration_reason: data.shareable_list.restoration_reason
+          ? data.shareable_list.restoration_reason
           : undefined,
         created_at: data.shareable_list.created_at,
         updated_at: data.shareable_list.updated_at

--- a/src/snowplow/shareableList/testData.ts
+++ b/src/snowplow/shareableList/testData.ts
@@ -1,4 +1,4 @@
-import { ShareableList, ListStatus, ModerationStatus } from './types';
+import { ShareableList, Visibility, ModerationStatus } from './types';
 
 export const testShareableListData: ShareableList['data'] = {
   shareable_list_external_id: 'test-shareable-list-external-id',
@@ -6,11 +6,13 @@ export const testShareableListData: ShareableList['data'] = {
   slug: 'test-shareable-list-slug',
   title: 'Test Shareable List Title',
   description: 'Test shareable list description',
-  status: ListStatus.PUBLIC,
+  status: Visibility.PUBLIC,
+  list_item_note_visibility: Visibility.PUBLIC,
   moderation_status: ModerationStatus.VISIBLE,
   moderated_by: 'fake-moderator-username',
   moderation_reason: 'SPAM',
   moderation_details: 'more details here',
+  restoration_reason: 'restoration details here',
   created_at: 1675978338, // 2023-02-09 16:32:18
   updated_at: 1675978338,
 };
@@ -20,7 +22,8 @@ export const testPartialShareableListData: ShareableList['data'] = {
   shareable_list_external_id: 'test-shareable-list-external-id',
   user_id: 12345,
   title: 'Test Shareable List Title',
-  status: ListStatus.PUBLIC,
+  status: Visibility.PUBLIC,
+  list_item_note_visibility: Visibility.PUBLIC,
   moderation_status: ModerationStatus.VISIBLE,
   created_at: 1675978338, // 2023-02-09 16:32:18
 };

--- a/src/snowplow/shareableList/types.ts
+++ b/src/snowplow/shareableList/types.ts
@@ -1,8 +1,8 @@
 import { SelfDescribingJson } from '@snowplow/tracker-core';
 
 export const shareableListEventSchema = {
-  objectUpdate: 'iglu:com.pocket/object_update/jsonschema/1-0-14',
-  shareable_list: 'iglu:com.pocket/shareable_list/jsonschema/1-0-5',
+  objectUpdate: 'iglu:com.pocket/object_update/jsonschema/1-0-15',
+  shareable_list: 'iglu:com.pocket/shareable_list/jsonschema/1-0-6',
 };
 
 export type ShareableListEventPayloadSnowplow = {
@@ -25,6 +25,7 @@ export enum EventType {
   SHAREABLE_LIST_PUBLISHED = 'shareable_list_published',
   SHAREABLE_LIST_UNPUBLISHED = 'shareable_list_unpublished',
   SHAREABLE_LIST_HIDDEN = 'shareable_list_hidden',
+  SHAREABLE_LIST_UNHIDDEN = 'shareable_list_unhidden',
 }
 
 export type ShareableList = Omit<SelfDescribingJson, 'data'> & {
@@ -34,17 +35,19 @@ export type ShareableList = Omit<SelfDescribingJson, 'data'> & {
     slug?: string;
     title: string;
     description?: string;
-    status: ListStatus;
+    status: Visibility;
+    list_item_note_visibility: Visibility;
     moderation_status: ModerationStatus;
     moderated_by?: string;
     moderation_reason?: string;
     moderation_details?: string;
+    restoration_reason?: string;
     created_at: number; // snowplow schema requires this field in seconds
     updated_at?: number; // snowplow schema requires this field in seconds
   };
 };
 
-export enum ListStatus {
+export enum Visibility {
   PRIVATE = 'PRIVATE',
   PUBLIC = 'PUBLIC',
 }

--- a/src/snowplow/shareableListItem/shareableListItemEventHandler.integration.ts
+++ b/src/snowplow/shareableListItem/shareableListItemEventHandler.integration.ts
@@ -43,6 +43,7 @@ function assertShareableListItemSchema(eventContext) {
         image_url: testShareableListItemData.image_url,
         authors: testShareableListItemData.authors,
         publisher: testShareableListItemData.publisher,
+        note: testShareableListItemData.note,
         sort_order: testShareableListItemData.sort_order,
         created_at: testShareableListItemData.created_at,
         updated_at: testShareableListItemData.updated_at,
@@ -140,6 +141,35 @@ describe('ShareableListItemEventHandler', () => {
     assertValidSnowplowObjectUpdateEvents(
       goodEvents.map((goodEvent) => goodEvent.rawEvent.parameters.ue_px),
       [EventType.SHAREABLE_LIST_ITEM_DELETED]
+    );
+  });
+
+  it('should send shareable_list_item_updated event to snowplow', async () => {
+    new ShareableListItemEventHandler().process({
+      ...testEventData,
+      eventType: EventType.SHAREABLE_LIST_ITEM_UPDATED,
+    });
+
+    // wait a sec * 3
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+
+    // make sure we only have good events
+    const allEvents = await getAllSnowplowEvents();
+    expect(allEvents.total).to.equal(1);
+    expect(allEvents.good).to.equal(1);
+    expect(allEvents.bad).to.equal(0);
+
+    const goodEvents = await getGoodSnowplowEvents();
+
+    const eventContext = parseSnowplowData(
+      goodEvents[0].rawEvent.parameters.cx
+    );
+
+    assertShareableListItemSchema(eventContext);
+
+    assertValidSnowplowObjectUpdateEvents(
+      goodEvents.map((goodEvent) => goodEvent.rawEvent.parameters.ue_px),
+      [EventType.SHAREABLE_LIST_ITEM_UPDATED]
     );
   });
 

--- a/src/snowplow/shareableListItem/shareableListItemEventHandler.ts
+++ b/src/snowplow/shareableListItem/shareableListItemEventHandler.ts
@@ -87,6 +87,9 @@ export class ShareableListItemEventHandler extends EventHandler {
         publisher: data.shareable_list_item.publisher
           ? data.shareable_list_item.publisher
           : undefined,
+        note: data.shareable_list_item.note
+          ? data.shareable_list_item.note
+          : undefined,
         sort_order: data.shareable_list_item.sort_order,
         created_at: data.shareable_list_item.created_at,
         updated_at: data.shareable_list_item.updated_at

--- a/src/snowplow/shareableListItem/testData.ts
+++ b/src/snowplow/shareableListItem/testData.ts
@@ -9,6 +9,7 @@ export const testShareableListItemData: ShareableListItem['data'] = {
   image_url: 'https://test-shareable-list-item-image-url.com',
   authors: ['Author1', 'Author2'],
   publisher: 'Fake Publisher',
+  note: 'some note',
   sort_order: 1,
   created_at: 1675978338, // 2023-02-09 16:32:18
   updated_at: 1675978338,

--- a/src/snowplow/shareableListItem/types.ts
+++ b/src/snowplow/shareableListItem/types.ts
@@ -1,8 +1,8 @@
 import { SelfDescribingJson } from '@snowplow/tracker-core';
 
 export const shareableListItemEventSchema = {
-  objectUpdate: 'iglu:com.pocket/object_update/jsonschema/1-0-14',
-  shareable_list_item: 'iglu:com.pocket/shareable_list_item/jsonschema/1-0-2',
+  objectUpdate: 'iglu:com.pocket/object_update/jsonschema/1-0-15',
+  shareable_list_item: 'iglu:com.pocket/shareable_list_item/jsonschema/1-0-3',
 };
 
 export type ShareableListItemEventPayloadSnowplow = {
@@ -20,6 +20,7 @@ export type ObjectUpdate = {
 
 export enum EventType {
   SHAREABLE_LIST_ITEM_CREATED = 'shareable_list_item_created',
+  SHAREABLE_LIST_ITEM_UPDATED = 'shareable_list_item_updated',
   SHAREABLE_LIST_ITEM_DELETED = 'shareable_list_item_deleted',
 }
 
@@ -33,6 +34,7 @@ export type ShareableListItem = Omit<SelfDescribingJson, 'data'> & {
     image_url?: string;
     authors?: string[];
     publisher?: string;
+    note?: string;
     sort_order: number;
     created_at: number; // snowplow schema requires this field in seconds
     updated_at?: number; // snowplow schema requires this field in seconds


### PR DESCRIPTION
## Goal

* Send `restorationReason` and `note` fields to Snowplow
* Add `shareable_list-unhidden` & `shareable_list_item_updated` triggers
* Update tests

## Todos

- [x] lets test in dev first

## Tickets

- [https://getpocket.atlassian.net/browse/OSL-397](https://getpocket.atlassian.net/browse/OSL-397)
- [https://getpocket.atlassian.net/browse/OSL-473](https://getpocket.atlassian.net/browse/OSL-473)
