### PR TITLE
fix(user-events): fix user events to correct schema

### DIFF
--- a/src/snowplow/user/types.ts
+++ b/src/snowplow/user/types.ts
@@ -73,5 +73,5 @@ export const userEventsSchema = {
   account: 'iglu:com.pocket/account/jsonschema/1-0-2',
   objectUpdate: 'iglu:com.pocket/object_update/jsonschema/1-0-9',
   user: 'iglu:com.pocket/user/jsonschema/1-0-0',
-  apiUser: 'iglu:com.pocket/api_user/jsonschema/1-0-0',
+  apiUser: 'iglu:com.pocket/api_user/jsonschema/1-0-2',
 };

--- a/src/snowplow/user/userEventHandler.ts
+++ b/src/snowplow/user/userEventHandler.ts
@@ -110,15 +110,23 @@ export class UserEventHandler extends EventHandler {
   private static generateUserContext(
     data: UserEventPayloadSnowplow
   ): UserContext {
+    const userDataWithoutGuid = {
+      email: data.user.email,
+      hashed_guid: data.user.hashedGuid,
+      user_id: parseInt(data.user.id),
+      hashed_user_id: data.user.hashedId,
+    };
+
+    if (data.user.guid) {
+      return {
+        schema: userEventsSchema.user,
+        data: { ...userDataWithoutGuid, guid: data.user.guid },
+      };
+    }
+
     return {
       schema: userEventsSchema.user,
-      data: {
-        email: data.user.email,
-        guid: data.user.guid,
-        hashed_guid: data.user.hashedGuid,
-        user_id: parseInt(data.user.id),
-        hashed_user_id: data.user.hashedId,
-      },
+      data: { ...userDataWithoutGuid },
     };
   }
 


### PR DESCRIPTION
### Goal
- Bump api_user snowplow schema version to 1-0-2
- Only set `guid` if not `null` and not `undefined` in the user event payload. It is an optional property on the `user` object in the snowplow schema.

## todo:
- test event emission to event bridge, if it works test the snowplow consumption


Slack thread: https://pocket.slack.com/archives/CR6T8BNCT/p1686242799145929

+ ticket: https://getpocket.atlassian.net/browse/INFRA-1246
+ ticket: https://getpocket.atlassian.net/browse/INFRA-1335
