### PR TITLE
OSL-576: sending list item metadata to Snowplow, update list item schema version

### DIFF
--- a/src/snowplow/shareableListItem/shareableListItemEventHandler.integration.ts
+++ b/src/snowplow/shareableListItem/shareableListItemEventHandler.integration.ts
@@ -38,6 +38,11 @@ function assertShareableListItemSchema(eventContext) {
         shareable_list_external_id:
           testShareableListItemData.shareable_list_external_id,
         given_url: testShareableListItemData.given_url,
+        title: testShareableListItemData.title,
+        excerpt: testShareableListItemData.excerpt,
+        image_url: testShareableListItemData.image_url,
+        authors: testShareableListItemData.authors,
+        publisher: testShareableListItemData.publisher,
         note: testShareableListItemData.note,
         sort_order: testShareableListItemData.sort_order,
         created_at: testShareableListItemData.created_at,

--- a/src/snowplow/shareableListItem/shareableListItemEventHandler.ts
+++ b/src/snowplow/shareableListItem/shareableListItemEventHandler.ts
@@ -72,6 +72,21 @@ export class ShareableListItemEventHandler extends EventHandler {
         shareable_list_external_id:
           data.shareable_list_item.shareable_list_external_id,
         given_url: data.shareable_list_item.given_url,
+        title: data.shareable_list_item.title
+          ? data.shareable_list_item.title
+          : undefined,
+        excerpt: data.shareable_list_item.excerpt
+          ? data.shareable_list_item.excerpt
+          : undefined,
+        image_url: data.shareable_list_item.image_url
+          ? data.shareable_list_item.image_url
+          : undefined,
+        authors: data.shareable_list_item.authors
+          ? data.shareable_list_item.authors
+          : undefined,
+        publisher: data.shareable_list_item.publisher
+          ? data.shareable_list_item.publisher
+          : undefined,
         note: data.shareable_list_item.note
           ? data.shareable_list_item.note
           : undefined,

--- a/src/snowplow/shareableListItem/testData.ts
+++ b/src/snowplow/shareableListItem/testData.ts
@@ -4,6 +4,11 @@ export const testShareableListItemData: ShareableListItem['data'] = {
   shareable_list_item_external_id: 'test-shareable-list-item-external-id',
   shareable_list_external_id: 'test-shareable-list-external-id',
   given_url: 'https://test-shareable-list-item-given-url.com',
+  title: 'Test Shareable List Item Title',
+  excerpt: 'Test shareable list item excerpt',
+  image_url: 'https://test-shareable-list-item-image-url.com',
+  authors: ['Author1', 'Author2'],
+  publisher: 'Fake Publisher',
   note: 'some note',
   sort_order: 1,
   created_at: 1675978338, // 2023-02-09 16:32:18

--- a/src/snowplow/shareableListItem/types.ts
+++ b/src/snowplow/shareableListItem/types.ts
@@ -2,7 +2,7 @@ import { SelfDescribingJson } from '@snowplow/tracker-core';
 
 export const shareableListItemEventSchema = {
   objectUpdate: 'iglu:com.pocket/object_update/jsonschema/1-0-15',
-  shareable_list_item: 'iglu:com.pocket/shareable_list_item/jsonschema/1-0-4',
+  shareable_list_item: 'iglu:com.pocket/shareable_list_item/jsonschema/1-0-5',
 };
 
 export type ShareableListItemEventPayloadSnowplow = {
@@ -29,6 +29,11 @@ export type ShareableListItem = Omit<SelfDescribingJson, 'data'> & {
     shareable_list_item_external_id: string;
     shareable_list_external_id: string;
     given_url: string;
+    title?: string;
+    excerpt?: string;
+    image_url?: string;
+    authors?: string[];
+    publisher?: string;
     note?: string;
     sort_order: number;
     created_at: number; // snowplow schema requires this field in seconds


### PR DESCRIPTION
## Goal

This is part of the foundational refactor rollback. Sending list item metadata to Snowplow.

## JIRA ticket:
* [https://getpocket.atlassian.net/browse/OSL-576](https://getpocket.atlassian.net/browse/OSL-576)
