### PR TITLE
SOCALPLAT-364: sending account-password-changed events to Snowplow

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.1'
 services:
   app:
-    image: node:18
+    image: node:18-slim@sha256:b175cd7f3358c399f7bcee9b1032b86b71b1afa4cfb4dd0db55d66f871475a3e
     platform: linux/amd64
     working_dir: /app
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,7 @@
 version: '3.1'
 services:
   app:
-    image: node:18-slim@sha256:b175cd7f3358c399f7bcee9b1032b86b71b1afa4cfb4dd0db55d66f871475a3e
-    platform: linux/amd64
+    image: node:18
     working_dir: /app
     ports:
       - '4015:4015'

--- a/src/eventConsumer/userEvents/userEventConsumer.ts
+++ b/src/eventConsumer/userEvents/userEventConsumer.ts
@@ -28,6 +28,7 @@ export type UserEventPayload = {
 export const DetailTypeToSnowplowMap: Record<string, EventTypeString> = {
   'account-deletion': 'ACCOUNT_DELETE',
   'account-email-updated': 'ACCOUNT_EMAIL_UPDATED',
+  'account-password-changed': 'ACCOUNT_PASSWORD_CHANGED',
 };
 
 export function userEventConsumer(requestBody: any) {

--- a/src/snowplow/user/types.ts
+++ b/src/snowplow/user/types.ts
@@ -30,6 +30,7 @@ export type ApiUser = {
 export enum EventType {
   ACCOUNT_DELETE = 'ACCOUNT_DELETE',
   ACCOUNT_EMAIL_UPDATED = 'ACCOUNT_EMAIL_UPDATED',
+  ACCOUNT_PASSWORD_CHANGED = 'ACCOUNT_PASSWORD_CHANGED',
 }
 
 export type BasicUserEventPayloadWithContext = {
@@ -62,16 +63,20 @@ export type UserEventPayloadSnowplow = BasicUserEventPayloadWithContext & {
   eventType: EventTypeString;
 };
 
-export type SnowplowEventType = 'account_email_updated' | 'account_delete';
+export type SnowplowEventType =
+  | 'account_email_updated'
+  | 'account_delete'
+  | 'account_password_changed';
 
 export const SnowplowEventMap: Record<EventTypeString, SnowplowEventType> = {
   ACCOUNT_DELETE: 'account_delete',
   ACCOUNT_EMAIL_UPDATED: 'account_email_updated',
+  ACCOUNT_PASSWORD_CHANGED: 'account_password_changed',
 };
 
 export const userEventsSchema = {
   account: 'iglu:com.pocket/account/jsonschema/1-0-2',
-  objectUpdate: 'iglu:com.pocket/object_update/jsonschema/1-0-9',
+  objectUpdate: 'iglu:com.pocket/object_update/jsonschema/1-0-16',
   user: 'iglu:com.pocket/user/jsonschema/1-0-0',
   apiUser: 'iglu:com.pocket/api_user/jsonschema/1-0-2',
 };


### PR DESCRIPTION
## Goal
Sending `account-password-changed` events to Snowplow

## References

JIRA ticket:
* [https://mozilla-hub.atlassian.net/browse/SOCIALPLAT-364](https://mozilla-hub.atlassian.net/browse/SOCIALPLAT-364)
